### PR TITLE
Remove outdated link

### DIFF
--- a/profiles/resources/default.cfg
+++ b/profiles/resources/default.cfg
@@ -1049,4 +1049,3 @@ ExternalXMLInjection_____Example XML injection RFI_____http://www.exploit-db.com
 ExternalCrossSiteScripting_____Gareth Hayes' Shazzer_____http://shazzer.co.uk/database
 ExternalCrossSiteScripting_____BeEF Project_____http://beefproject.com/
 ExternalCrossSiteScripting_____XSS Proxy_____http://xss-proxy.sourceforge.net/
-ExternalCrossSiteScripting_____GNU citizen backframe_____http://www.gnucitizen.org/projects/backframe/


### PR DESCRIPTION
Quote from the Backframe website: 

> UPDATE 09/05/2011: We’ve stopped supporting the online version. However, you can still download the 
> sources from the public SVN repository over here.
