### PR TITLE
update kali_setup.sh

### DIFF
--- a/install/kali_install.sh
+++ b/install/kali_install.sh
@@ -37,7 +37,8 @@ get_config_value(){
 echo "\n[*] Running the master install script for OWASP Offensive Web Testing Framework"
 
 # It is easier to work from the root folder of OWTF
-cd ../
+WD=`dirname $0`
+cd $WD/../
 
 echo "\n[*] Install restricted tools? [Y/n]"
 read a


### PR DESCRIPTION
This should fix error's when script called from outside of install directory by directly specifying the path. here we are identifying the directory of script and then going one level up. Correct me if this is wrong approach.
