### PR TITLE
OWASP Dependency check has been added as an external plugin.

### DIFF
--- a/plugins/web/external/Web_Application_Fingerprint@OWASP-IG-004.py
+++ b/plugins/web/external/Web_Application_Fingerprint@OWASP-IG-004.py
@@ -37,6 +37,6 @@ DESCRIPTION = "Plugin to assist manual testing"
 
 def run(Core, PluginInfo):
 	#Core.Config.Show()
-	Content = "Intended to show helpful info in the future"
+	Content = Core.PluginHelper.DrawResourceLinkList('Online Resources', Core.Config.GetResources('WebAppFingerprint'))
 	return Content
 

--- a/profiles/resources/default.cfg
+++ b/profiles/resources/default.cfg
@@ -1145,6 +1145,7 @@ ExternalRememberPasswordAndReset_____OWASP's Choosing and Using Security Questio
 ExternalCredentialsTransport_____FireSheep: A Firefox extension that demonstrates HTTP session hijacking attacks_____http://codebutler.github.com/firesheep/
 ExternalCredentialsTransport_____SSLStrip: HTTPS stripping attack tool_____http://www.thoughtcrime.org/software/sslstrip/
 ExternalCredentialsTransport_____CookieCadger: An auditing tool for Wi-Fi or wired Ethernet connections_____https://www.cookiecadger.com/
+ExternalWebAppFingerprint_____Dependency Check: A utility that identifies project dependencies and checks if there are any known, publicly disclosed, vulnerabilities_____https://www.owasp.org/index.php/OWASP_Dependency_Check
 FtpProbeMethods_____Ftp Probing using _____@@@TOOL_METASPLOIT_DIR@@@/msfcli auxiliary/scanner/ftp/anonymous RHOSTS=@@@HOST_IP@@@ RPORT=@@@FTP_PORT_NUMBER@@@ FTPUSER="anonymous" FTPPASS="john@microsoft.com" E
 FtpProbeMethods_____Ftp Probing using _____@@@TOOL_METASPLOIT_DIR@@@/msfcli auxiliary/scanner/ftp/ftp_version RHOSTS=@@@HOST_IP@@@ RPORT=@@@FTP_PORT_NUMBER@@@ FTPUSER="anonymous" FTPPASS="john@microsoft.com" E
 BruteFtpProbeMethods_____Ftp Probing using _____@@@TOOL_METASPLOIT_DIR@@@/msfcli auxiliary/scanner/ftp/ftp_login RHOSTS=@@@HOST_IP@@@ RPORT=@@@FTP_PORT_NUMBER@@@ USERPASS_FILE=@@@USERNAME_PASSWORD_FILE@@@ E


### PR DESCRIPTION
Dependency-Check is a utility that identifies project dependencies and checks if there are any known, publicly disclosed, vulnerabilities. The utility has been added to OWTF external plugins list.
