### PR TITLE
Remove old reference to kali_install.sh

### DIFF
--- a/framework/config/health_check.py
+++ b/framework/config/health_check.py
@@ -89,11 +89,6 @@ class HealthCheck(object):
             " - Define where your tools are here: " +
             str(self.core.Config.Profiles['g'])
             )
-        cprint(
-            " - Use the " +
-            self.core.Config.RootDir +
-            "/install/kali_install.sh script to install missing tools"
-            )
         if (self.core.Config.Get('INTERACTIVE') and
                 'n' == raw_input("Continue anyway? [Y/n]")):
             self.core.Error.FrameworkAbort("Aborted by user")


### PR DESCRIPTION
The kali_install.sh does not exists anymore after the changes from b3dfa3211a.
