### PR TITLE
-f option works

### DIFF
--- a/framework/config/config.py
+++ b/framework/config/config.py
@@ -194,11 +194,13 @@ class Config(BaseComponent, ConfigInterface):
         scope = self.prepare_url_scope(options['Scope'], options['PluginGroup'])
         added_targets = []
         for target in scope:
+            added_targets.append(target)
             try:
                 self.target.AddTarget(target)
                 added_targets.append(target)
             except DBIntegrityException:
                 logging.warning("%s already exists in DB" % target)
+                added_targets.append(target)
             except UnresolvableTargetException as e:
                 logging.error("%s" % e.parameter)
         return(added_targets)

--- a/framework/config/config.py
+++ b/framework/config/config.py
@@ -194,7 +194,6 @@ class Config(BaseComponent, ConfigInterface):
         scope = self.prepare_url_scope(options['Scope'], options['PluginGroup'])
         added_targets = []
         for target in scope:
-            added_targets.append(target)
             try:
                 self.target.AddTarget(target)
                 added_targets.append(target)

--- a/framework/error_handler.py
+++ b/framework/error_handler.py
@@ -105,7 +105,6 @@ class ErrorHandler(BaseComponent, ErrorHandlerInterface):
 
         try:
             if not(ErrorHandler.cl_arg["Force_Overwrite"]):
-                cprint("This module is getting executed")
                 self.db_error.Add(message, trace)  # Log error in the DB.
         except AttributeError:
             cprint("ERROR: DB is not setup yet: cannot log errors to file!")

--- a/framework/error_handler.py
+++ b/framework/error_handler.py
@@ -46,11 +46,11 @@ from framework.lib.exceptions import FrameworkAbortException, \
 from framework.lib.general import cprint
 from framework.utils import OutputCleaner
 
-
 class ErrorHandler(BaseComponent, ErrorHandlerInterface):
     Command = ''
     PaddingLength = 100
     COMPONENT_NAME = "error_handler"
+    cl_arg = None
 
     def __init__(self):
         self.register_in_service_locator()
@@ -102,8 +102,11 @@ class ErrorHandler(BaseComponent, ErrorHandlerInterface):
         return message
 
     def LogError(self, message, trace=None):
+
         try:
-            self.db_error.Add(message, trace)  # Log error in the DB.
+            if not(ErrorHandler.cl_arg["Force_Overwrite"]):
+                cprint("This module is getting executed")
+                self.db_error.Add(message, trace)  # Log error in the DB.
         except AttributeError:
             cprint("ERROR: DB is not setup yet: cannot log errors to file!")
 
@@ -123,6 +126,10 @@ class ErrorHandler(BaseComponent, ErrorHandlerInterface):
         output += "\n"+self.Padding
         cprint(output)
         self.LogError(message, err_trace)
+
+    @staticmethod
+    def set_args(args):
+        ErrorHandler.cl_arg = args
 
     def Add(self, message, bugType='owtf'):
         if 'owtf' == bugType:

--- a/owtf.py
+++ b/owtf.py
@@ -42,7 +42,7 @@ verify_dependencies(os.path.dirname(os.path.abspath(sys.argv[0])) or '.')
 
 
 import argparse
-from framework import core as core_mod
+from framework import core as core_mod, error_handler
 from framework.dependency_management.component_initialiser import ComponentInitialiser, DatabaseNotRunningException
 from framework.dependency_management.dependency_resolver import ServiceLocator
 from framework.lib.general import *
@@ -192,7 +192,6 @@ def get_args(args):
         help='Run OWTF without its Web UI.')
     parser.add_argument('Targets', nargs='*', help='List of Targets')
     return parser.parse_args(args)
-
 
 def get_args_for_update(args):
     parser = argparse.ArgumentParser(
@@ -512,6 +511,7 @@ def main(args):
                 ServiceLocator.get_component("config").FrameworkConfigGet('VERSION'),
                 ServiceLocator.get_component("config").FrameworkConfigGet('RELEASE'))
             )
+        error_handler.ErrorHandler.cl_arg = args
         run_owtf(core, args)
     else:
         # First confirming that --update flag is present in args and then


### PR DESCRIPTION
Added the target to the target list when there is an IntegrityError(already the target exists in the DB)
Error messages won't be saved to the DB when -f option is used