### PR TITLE
Fix string comparison issue in db_config_setup.sh

### DIFF
--- a/install/db_config_setup.sh
+++ b/install/db_config_setup.sh
@@ -44,7 +44,7 @@ cfg_only=false
 
 for arg in "$@"
 do
-    if [ "$arg" == "--cfg-only" ]; then
+    if [ "$arg" = "--cfg-only" ]; then
         cfg_only=true
     else
         RootDir=$arg


### PR DESCRIPTION
Comparison error caused by starting the script with POSIX shell