### PR TITLE
Upgrade default python setuptools package to v18.1

### DIFF
--- a/install/owtf.pip
+++ b/install/owtf.pip
@@ -18,5 +18,6 @@ python-owasp-zap-v2==0.0.9
 PyVirtualDisplay==0.1.5
 rdflib==4.1.2
 selenium==2.43.0
+setuptools==18.1
 SQLAlchemy==0.9.7
 tornado==4.0.2


### PR DESCRIPTION
Default python-setuptools installs a deprecated version(0.6rc11)