### PR TITLE
added check for kali linux block to run only if distro is kali

### DIFF
--- a/install/distro-independent.cfg
+++ b/install/distro-independent.cfg
@@ -8,6 +8,10 @@
 directory = /tmp/owtf-install/pip/%(Pid)s
 command = command -v pip2 >/dev/null || { wget --tries=3 https://bootstrap.pypa.io/get-pip.py; sudo python get-pip.py;}
 
+[pipsecure]
+directory = %(Pid)s
+command = sudo pip install pyopenssl ndg-httpsclient pyasn1
+
 [Httprint]
 directory = %(RootDir)s/tools/restricted/httprint
 command = wget --tries=3 http://www.net-square.com/_assets/httprint_linux_301.zip; unzip *.zip; rm -f *.zip;


### PR DESCRIPTION
this is a simple check added by a new if condition the whole block around kali linux should only run if distro is kali.

At later stage we should reduce this code also and may be create different distro profile or deprecate support for kali 1 as its not officially supported.

Fix #534 