### PR TITLE
Allow the install to proceed is user is root

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -56,7 +56,7 @@ class Installer(object):
     def check_sudo():
         """Checks if the user has sudo access"""
         sudo = os.system("sudo -v")
-        if sudo == "0":
+        if sudo == 0:
             return
         else:
             print("[WARNING] Your user does not have sudo priveleges. Some OWTF components require sudo permissions to install")


### PR DESCRIPTION
A change recently introduced check if the user has "sudo" permissions.

The check_sudo() function should also allow the installation to proceed if the user is root.

This Pull Requests checks  if the user has UID = 0 (equivalent to root) and proceed if it does have so, otherwise, print's the warning and exits cleanly. 