### PR TITLE
Perform "apt-get update" before install packages. Resolves #540

### DIFF
--- a/install/kali/install.sh
+++ b/install/kali/install.sh
@@ -14,6 +14,8 @@ RootDir=$1
 ########### Pip is the foremost thing that must be installed along with some needed dependencies for python libraries
 
 apt_wrapper_path="$RootDir/install/aptitude-wrapper.sh"
+# Perform apt-get update before starting to install all packages, so we can get the latests manifests and packages versions
+sudo apt-get update
 sudo -E "$apt_wrapper_path" python-pip xvfb xserver-xephyr libxml2-dev libxslt-dev
 export PYCURL_SSL_LIBRARY=gnutls # Needed for installation of pycurl using pip in kali
 


### PR DESCRIPTION
Update the manifests from upstream kali repo in order to get the latest package package versions before performing intallation of packages required by OWTF.
This will address issues currently found when trying install of OWTF on a fresh Kali 2.0 VM downloaded from Offsec Website. Resolves #540

Signed-off-by: Doug Morato <dm@corp.io>