### PR TITLE
IDE specific auto-generated files now in .gitignore. Fixes #562

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 #####################################
 *.pyc
 *.swp
-.idea/
 
 # Directories with potential license restrictions that prevent re-distribution #
 ################################################################################
@@ -35,3 +34,24 @@ zest/zest_lib/*
 zest/zest_runner_lib/*
 zest/zest.jar
 zest/zest_runner.jar
+
+# Pycharm (Jetbrains) IDE Specific files #
+##########################################
+.idea/*
+ 
+# PyDev (Eclipse) IDE Specific Files #
+######################################
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+local.properties
+.settings/
+.loadpath
+*.project
+*.pydevproject
+
+# YouCompleteMe - VIM plugin Specific Files #
+#############################################
+.ycm_extra_conf.py


### PR DESCRIPTION
As described in #562, the necessary files and directories for the following IDEs/ editors have been included in .gitignore :
- _**Pycharm IDE** - Jetbrains._
  - `.idea/` directory and all its sub-contents in top level directory.
- _**PyDev IDE** - Eclipse._
  - mainly `*.project` and `*.pydevproject` files, along with some other common eclipse generated files.
- _**YouCompleteMe** - Vim._
  - `.ycm_extra_conf.py` in top level directory.