### PR TITLE
Ensures execution of Debian and Samurai scripts. Fixes #572

### DIFF
--- a/install/aptitude-wrapper.sh
+++ b/install/aptitude-wrapper.sh
@@ -39,7 +39,7 @@ do
 done
 
 # Check if the current available disk size is enough.
-while [ "$(available_disk_size)" -lt "$size" ]; do
+while [ "${reset}$(available_disk_size)" -lt "$size" ]; do
     echo "${warning}[!] Not enough available space for downloading $@${reset}"
     echo "${warning}[!] Please free the required size and proceed or skip this step (press \'n\') [Y/n]${reset}"
     read yn

--- a/install/db_config_setup.sh
+++ b/install/db_config_setup.sh
@@ -39,8 +39,8 @@ db_name="owtfdb"
 db_user="owtf_db_user"
 db_pass=$(head /dev/random -c8 | od -tx1 -w16 | head -n1 | cut -d' ' -f2- | tr -d ' ')
 
-if [ ! -f $db_config_file ]; then
-    mkdir -p "$(dirname $db_config_file)"
+if [ ! -f ${db_config_file} ]; then
+    mkdir -p "$(dirname ${db_config_file})"
     echo "${info}[*] Creating default config at $db_config_file${reset}"
     echo "${warning}[!] Don't forget to edit $db_config_file${reset}"
     echo "

--- a/install/debian/install.sh
+++ b/install/debian/install.sh
@@ -50,7 +50,7 @@ sudo sh -c "echo 'deb http://repo.kali.org/kali kali-bleeding-edge main contrib 
 
 # Patch script for debian apt
 echo "${normal}[*] Adding apt preferences in order to keep Debian free from Kali garbage as much as possible :P${reset}"
-"$RootDir/install/debian/pref.sh"
+sh "$RootDir/install/debian/pref.sh"
 
 sudo "$apt_wrapper_path" update
 

--- a/install/kali/install.sh
+++ b/install/kali/install.sh
@@ -46,9 +46,9 @@ echo "${info}[*] Installing Tor${reset}"
 sudo -E "$apt_wrapper_path" tor
 
 ########## Patch scripts
-"$RootDir/install/kali/kali_patch_w3af.sh"
-"$RootDir/install/kali/kali_patch_nikto.sh"
-"$RootDir/install/kali/kali_patch_tlssled.sh"
+sh "$RootDir/install/kali/kali_patch_w3af.sh"
+sh "$RootDir/install/kali/kali_patch_nikto.sh"
+sh "$RootDir/install/kali/kali_patch_tlssled.sh"
 ###### Dictionaries missing in Kali
 mkdir -p ${RootDir}/dictionaries/restricted
 cd ${RootDir}/dictionaries/restricted

--- a/install/samurai/install.sh
+++ b/install/samurai/install.sh
@@ -38,7 +38,7 @@ echo "${normal}[*] Done!${reset}"
 #fi
 
 ########## Remove default ruby-bundler to avoid with Metasploit later on
-"$RootDir/install/samurai/samurai_wtf_patch_metasploit.sh" ${RootDir}
+sh "$RootDir/install/samurai/samurai_wtf_patch_metasploit.sh" ${RootDir}
 
 ########## Installing missing tools
 echo "${normal}[*] Installing missing tools${reset}"
@@ -48,9 +48,9 @@ echo "${info}[*] Installing Tor${reset}"
 sudo -E apt-get install tor
 
 ########## Patch scripts
-"$RootDir/install/kali/samurai_wtf_patch_w3af.sh"
-"$RootDir/install/samurai/samurai_wtf_patch_nikto.sh"
-"$RootDir/install/samurai/samurai_wtf_patch_tlssled.sh"
+sh "$RootDir/install/kali/samurai_wtf_patch_w3af.sh"
+sh "$RootDir/install/samurai/samurai_wtf_patch_nikto.sh"
+sh "$RootDir/install/samurai/samurai_wtf_patch_tlssled.sh"
 
 ###### Dictionaries missing in Samurai-WTF
 mkdir -p ${RootDir}/dictionaries/restricted


### PR DESCRIPTION
All the statements in shell scripts, which are meant to execute other shell scripts are prepended with "sh" in order to make sure that the script runs even if the permissions of script have the executable bit unset.

This workaround was enacted following the suggestion by @delta24 on #572 :
_"A possibly clean solution is to add either `sh` or `bash` in front of the script names everywhere. That way we don't play with permissions and source remains clean."_
