### PR TITLE
Fix Set-Cookie header handling in proxy. Fixes #582

### DIFF
--- a/framework/http/proxy/cache_handler.py
+++ b/framework/http/proxy/cache_handler.py
@@ -10,6 +10,8 @@ import base64
 import hashlib
 import datetime
 from framework.lib.filelock import FileLock
+import tornado.httputil
+
 
 class CacheHandler(object):
     """
@@ -136,7 +138,7 @@ def response_from_cache(file_path):
     dummyResponse = DummyObject()
     cache_dict = json.loads(open(file_path, 'r').read())
     dummyResponse.code = cache_dict["response_code"]
-    dummyResponse.headers = cache_dict["response_headers"]
+    dummyResponse.headers = tornado.httputil.HTTPHeaders(cache_dict["response_headers"])
     dummyResponse.header_string = '\r\n'.join(["%s: %s" % (name, value) for name, value in cache_dict["response_headers"].iteritems()])
     if cache_dict["binary_response"] == True:
         dummyResponse.body = base64.b64decode(cache_dict["response_body"])

--- a/framework/http/proxy/proxy.py
+++ b/framework/http/proxy/proxy.py
@@ -73,7 +73,7 @@ class ProxyHandler(tornado.web.RequestHandler):
     # This function writes a new response & caches it
     def finish_response(self, response):
         self.set_status(response.code)
-        for header, value in list(response.headers.items()):
+        for header, value in response.headers.get_all():
             if header == "Set-Cookie":
                 self.add_header(header, value)
             else:


### PR DESCRIPTION
Replaces `headers.get_items()` to `headers.get_all()` in **framework/http/proxy/proxy.py** as directed in #582 to overcome the error.

The relevant screenshots:
* Before fixing:
![image](https://cloud.githubusercontent.com/assets/10494087/13660217/d6cbd520-e6ad-11e5-9c37-8ee4febd7963.png)

* After fixing:
![image](https://cloud.githubusercontent.com/assets/10494087/13660553/21416306-e6b1-11e5-89aa-aca5b6a073ef.png)
