### PR TITLE
Fixed return value of get_config_value() function

### DIFF
--- a/install/db_config_setup.sh
+++ b/install/db_config_setup.sh
@@ -13,7 +13,7 @@ get_config_value(){
     parameter=$1
     file=$2
 
-    echo "${info}$(grep -i ${parameter} ${file} | sed  "s|$parameter: ||g;s|~|$HOME|g")${reset}"
+    echo "$(grep -i ${parameter} ${file} | sed  "s|$parameter: ||g;s|~|$HOME|g")"
 }
 
 # Simple command line argument handler.

--- a/install/kali/install.sh
+++ b/install/kali/install.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 
+
+usage="Usage:./install.sh OWTF_PROJECT_FOLDER"
+if [ $# -ne 1 ]; then
+    echo $usage
+    exit 1
+fi    
 # bring in the color variables: `normal`, `info`, `warning`, `danger`, `reset`
 . "$(dirname "$(readlink -f "$0")")/../colors.sh"
 

--- a/install/kali/install.sh
+++ b/install/kali/install.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env sh
 
-
-usage="Usage:./install.sh OWTF_PROJECT_FOLDER"
-if [ $# -ne 1 ]; then
-    echo $usage
-    exit 1
-fi    
 # bring in the color variables: `normal`, `info`, `warning`, `danger`, `reset`
 . "$(dirname "$(readlink -f "$0")")/../colors.sh"
 

--- a/install/proxy_CA.sh
+++ b/install/proxy_CA.sh
@@ -11,7 +11,7 @@ get_config_value(){
     parameter=$1
     file=$2
     
-    echo "${info}$(grep -i ${parameter} ${file} | sed  "s|$parameter: ||g;s|~|$HOME|g")${reset}"
+    echo "$(grep -i ${parameter} ${file} | sed  "s|$parameter: ||g;s|~|$HOME|g")"
 }
 
 config_file="$RootDir/profiles/general/default.cfg"


### PR DESCRIPTION

Fixed problem with these scripts.I've tried to install owtf on my Kali Linux and the scripts were not creating the .owtf/proxy folder  and .owtf/db.cfg properly. That was  because the function get_config_value function (included in both scripts) was returning a bad value because the colours were making a bad path to the desired path.

And usage added to the /install/kali/install.sh script were teh OWTF project folder is required
