### PR TITLE
Fix for 'illegal number' problem of aptitude wrapper.sh

### DIFF
--- a/install/aptitude-wrapper.sh
+++ b/install/aptitude-wrapper.sh
@@ -12,7 +12,7 @@ usage() {
 }
 
 available_disk_size() {
-    echo "${info}$(($(stat -f --format="%a*%S" .)))${reset}"
+    echo "$(($(stat -f --format="%a*%S" .)))"
 }
 
 # Bail out if not root privileges


### PR DESCRIPTION
The 'disk space' available was also colored cyan while colorizing the logs in the file **install/aptitude-wrapper.sh**, so it couldn't be compared with numerical data due to presence of stray ANSI codes. This PR intends to fix that error.