### PR TITLE
UI add targets button bug fixed

### DIFF
--- a/framework/interface/templates/target_manager.html
+++ b/framework/interface/templates/target_manager.html
@@ -338,6 +338,7 @@ function newTargets(targetUrlsString, button) {
             $("#newTargetUrls").val("");
         } else { // Not a valid url
             alertFail(escapeHtml(line)+" is not a valid url");
+            enableInput("#addTargetBtn"); // Enable the button if url is not valid
         }
     });
 


### PR DESCRIPTION
UI Add Targets button gets disabled even if the url is not valid. Enabled the add targets button, when url is not valid. Addresses bug #496