### PR TITLE
Enhanced installer script 

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -26,6 +26,22 @@ class Installer(object):
         self.parser.add_argument('--no-user-input', help='run script with default options for user input', action="store_true")
         self.parser.add_argument('--core-only', help='install only owtf dependencies, skip optional tools', action="store_true")
 
+    def print_success(self, error_code):
+        if(error_code == 1):
+            Colorizer.danger("\n[!] The installation was not successful.")
+            Colorizer.normal("[*] Visit https://github.com/owtf/owtf for help ")
+        else:
+            Colorizer.success("[*] Finished!")
+            Colorizer.info("[*] Start OWTF by running './owtf.py' in parent directory")
+
+    def is_compatible(self):
+        compatible_value = os.system("which apt-get >> /dev/null")
+        if(compatible_value>>8 == 1):
+            return False
+        else:
+            return True
+
+
     def create_directory(self, directory):
         # Create parent directories as necessary
         try:
@@ -93,7 +109,19 @@ class Installer(object):
         cp = ConfigParser.ConfigParser({"RootDir":self.RootDir, "Pid":self.pid})
         cp.read(self.distros_cfg)
 
-        #Try get the distro automatically
+        # Check if the current distribution is compatible
+        
+
+        if not self.is_compatible():
+            Colorizer.danger("\n[!] You don't seem to have the apt package manager installed. "
+                "This means that your distribution is not fully supported (yet).")
+
+            # yes is assumed for any other input
+            response = raw_input("\nContinue installation anyway? [Y/N] : ")
+            if(response == 'N' or response == 'n'):
+                return 1
+
+        # Try detecting the distro automatically
         distro, version, arch = platform.linux_distribution()
         distro_num = 0
         if "kali" in distro.lower():
@@ -102,7 +130,8 @@ class Installer(object):
             distro_num = 2
         elif "debian" in distro.lower():
             distro_num = 3
-
+        elif self.is_compatible():
+            distro_num = 3
         # Loop until proper input is received
         while True:
             if distro_num != 0:
@@ -235,7 +264,6 @@ if __name__ == "__main__":
     installer = Installer(RootDir)
     Colorizer.info("[DEBUG] Last commit hash: %s" % installer.version(RootDir))
     installer.check_sudo()
-    installer.install(sys.argv[1:])
-
-    Colorizer.success("[*] Finished!")
-    Colorizer.info("[*] Start OWTF by running './owtf.py' in parent directory")
+    resp_code = installer.install(sys.argv[1:]) 
+    installer.print_success(resp_code)
+    


### PR DESCRIPTION
This should be a fix to #607 I have tested it on Ubuntu, Fedora and Kali Linux. 

The script tries to detect an instance of `apt-get` and assigns the Debian tag to the OS if is found. If `apt-get` is not found. it will raise an error and ask the user if he wants to proceed as discussed with @7a and @ner0x652 on IRC. This way, any user who has `apt` will now be tagged as a Debian user and the installation will continue automatically (Tested on Ubuntu) . 

Screenshot of Ubuntu : 
![screenshot from 2016-03-18 16-35-33](https://cloud.githubusercontent.com/assets/9546091/13876749/63ebb6c6-ed2c-11e5-8057-2035d54100a2.png)

A user without `apt` will see screens like this (Screenshots of Fedora) : 
![fedora1](https://cloud.githubusercontent.com/assets/9546091/13876809/c58ed11a-ed2c-11e5-8c68-89fc9655b15b.png)
If the user wishes not to continue, he gets the following message : 
![fedora2](https://cloud.githubusercontent.com/assets/9546091/13876814/cda6d758-ed2c-11e5-9419-82ad95cb9ed5.png)

If the user wishes to continue, he is given the selection screen for the OS (I'm doing this to eliminate the edge cases, where a user might have installed a spin/derivative of an OS mentioned there)

![fedora3](https://cloud.githubusercontent.com/assets/9546091/13876864/22643948-ed2d-11e5-8df4-696b83d07ac5.png)

After selection of the OS, the installation continues as expected (for the brave user :man_with_gua_pi_mao: )

![fedora4](https://cloud.githubusercontent.com/assets/9546091/13876886/4e86318e-ed2d-11e5-9b1c-8563e6b308da.png)

It should auto-detect Kali fine as before :)

**Edit:** 

Tested on Kali as well. Here you go : 
![screenshot from 2016-03-19 18 03 23](https://cloud.githubusercontent.com/assets/9546091/13898619/9d4a1ecc-edad-11e5-82da-39af4d0b1f68.png)





