### PR TITLE
Fixed mavitunasecurity.com redirection

### DIFF
--- a/dictionaries/README
+++ b/dictionaries/README
@@ -1,4 +1,4 @@
 Have a look at this for more background:
 
 http://pauldotcom.com/2011/08/dirbuster-to-burp-the-missing.html
-http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/
+https://www.netsparker.com/blog/web-security/svn-digger-better-lists-for-forced-browsing/

--- a/dictionaries/install_dicts.sh
+++ b/dictionaries/install_dicts.sh
@@ -96,21 +96,21 @@ mkdir -p $INSTALL_DIR
     else
         echo "WARNING: CMS dictionaries are already installed, skipping"
     fi
-    
+
 	cd $INSTALL_DIR
 
     IsInstalled "svndigger" # Not using $INSTALL_DIR because we did a cd into $INSTALL_DIR
     if [ $? -eq 0 ]; then # Not installed
         #Fetching svndigger dicts
         echo "\n[*] Fetching SVNDigger dictionaries"
-        WgetInstall "http://www.mavitunasecurity.com/s/research/SVNDigger.zip" "svndigger" "zip"
+        WgetInstall "http://www.netsparker.com/s/research/SVNDigger.zip" "svndigger" "zip"
         echo "[*] Done"
     else
         echo "WARNING: SVNDIGGER dictionaries are already installed, skipping"
     fi
 
     IsInstalled "dirbuster"
-    if [ $? -eq 0 ]; then # Not installed    
+    if [ $? -eq 0 ]; then # Not installed
         # Copying dirbuster dicts
         echo "\n[*] Copying Dirbuster dictionaries"
         mkdir -p dirbuster

--- a/dictionaries/install_dicts.sh
+++ b/dictionaries/install_dicts.sh
@@ -103,7 +103,7 @@ mkdir -p $INSTALL_DIR
     if [ $? -eq 0 ]; then # Not installed
         #Fetching svndigger dicts
         echo "\n[*] Fetching SVNDigger dictionaries"
-        WgetInstall "http://www.netsparker.com/s/research/SVNDigger.zip" "svndigger" "zip"
+        WgetInstall "https://www.netsparker.com/s/research/SVNDigger.zip" "svndigger" "zip"
         echo "[*] Done"
     else
         echo "WARNING: SVNDIGGER dictionaries are already installed, skipping"


### PR DESCRIPTION
Replaced mavitunasecurity.com with netsparker.com  as it was redirecting to netsparker.com. Rest of the url remains same.