### PR TITLE
Fixed github.com redirection urls

### DIFF
--- a/install/debian/install.sh
+++ b/install/debian/install.sh
@@ -23,7 +23,7 @@ sudo apt-get update
 
 # Grab and install pip
 echo "${info}[*] Installing pip using get-pip.py${reset}"
-wget --user-agent="${user_agent}" --tries=3 https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+wget --user-agent="${user_agent}" --tries=3 https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py
 sudo -E python get-pip.py
 
 # Install headers for x86_64-linux-gnu-gcc

--- a/install/distro-independent.cfg
+++ b/install/distro-independent.cfg
@@ -63,7 +63,7 @@ command = wget --user-agent="Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/2010010
 
 [Fuzzdb]
 directory = %(RootDir)s/dictionaries/fuzzdb
-command = wget --user-agent="Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/15.0" --tries=3 https://github.com/fuzzdb-project/fuzzdb/archive/master.zip; unzip *.zip; rm -f *.zip
+command = wget --user-agent="Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/15.0" --tries=3 https://codeload.github.com/fuzzdb-project/fuzzdb/zip/master; unzip *.zip; rm -f *.zip
 
 [Raft Dictionaries]
 directory = %(RootDir)s/dictionaries/restricted/raft

--- a/install/install_zest_jars.sh
+++ b/install/install_zest_jars.sh
@@ -16,7 +16,7 @@ fi
 
 upstream_hash="$(wget --user-agent="${user_agent}" --tries=3 -O- -q https://raw.githubusercontent.com/owtf/owtf-zest-jars/master/release.hash)"
 install() {
-  wget --user-agent="${user_agent}" --tries=3 https://api.github.com/repos/owtf/owtf-zest-jars/tarball -O zest-jars.tar.gz
+  wget --user-agent="${user_agent}" --tries=3 https://codeload.github.com/owtf/owtf-zest-jars/legacy.tar.gz/master -O zest-jars.tar.gz
   tar zxf zest-jars.tar.gz
   cd */.
   cp -r * ${RootDir}/zest
@@ -37,4 +37,3 @@ else
     echo "${normal}Hashes match. Continuing..${reset}"
   fi
 fi
-


### PR DESCRIPTION
Some github.com urls are redirecting. Fixed them.

1) https://api.github.com/repos/owtf/owtf-zest-jars/tarball
302 redirection

2) https://github.com/fuzzdb-project/fuzzdb/archive/master.zip
302 redirection

3) https://raw.github.com/pypa/pip/master/contrib/get-pip.py
301 redirection