### PR TITLE
Removed unnecessary click

### DIFF
--- a/framework/interface/templates/plugin_report.html
+++ b/framework/interface/templates/plugin_report.html
@@ -19,9 +19,10 @@
                 <div class="panel-body">
                     <ul class="nav nav-tabs">
                         <li class="brand disabled"><a class="btn" disabled="disabled">Type:</a></li>
+                        {% set pactive = 'active' if len(poutput_list) == 1 else '' %}
                         {% for poutput in poutput_list %}
                         {% set pkey = poutput['plugin_type'] + '_' + poutput['plugin_code'] %}
-                        <li>
+                        <li class="{{ pactive }}">
                             <a id="tab_{{ pkey }}" href="#{{ poutput['plugin_group'] }}__{{ poutput['plugin_type'] }}__{{ test_code }}" data-toggle="tab">
                                 {{ poutput['plugin_type'].replace('_',' ') }}
                             </a>
@@ -33,7 +34,7 @@
                     <div class="tab-content">
                         {% for poutput in poutput_list %}
                         {% set pkey = poutput['plugin_type'] + '_' + poutput['plugin_code'] %}
-                        <div class="tab-pane" id="{{ poutput['plugin_group'] }}__{{ poutput['plugin_type'] }}__{{ test_code }}">
+                        <div class="tab-pane {{ pactive }}" id="{{ poutput['plugin_group'] }}__{{ poutput['plugin_type'] }}__{{ test_code }}">
                             <div class="pull-left" data-toggle="buttons-checkbox">
                                 <blockquote><h4>{{ poutput['plugin_type'].replace('_',' ').capitalize() }}</h4><small>{{ poutput['plugin_code'] }}</small></blockquote>
                             </div>


### PR DESCRIPTION
When viewing a target report for a plugin, if there is only one type of that plugin available. i.e. only active, or only bruteforce, then that tab will be open by default upon expanding the accordion


## Related Issue
https://github.com/owtf/owtf/issues/429

## Motivation and Context
Reduces number of clicks requred to view reports.

## Reviewers
@delta24

## How Has This Been Tested?
Tested on a plugin with 1 type and also on plugins with multiple types.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (Small improvement to existing functionality)

### Checklist:
- [x] My code follows the code style (modified PEP8) of this project. 
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.