### PR TITLE
Fixes #639 and properly fixes #379

### DIFF
--- a/framework/db/command_register.py
+++ b/framework/db/command_register.py
@@ -47,9 +47,13 @@ class CommandRegister(BaseComponent, CommandRegisterInterface):
         if register_entry:
             # If the command was completed and the plugin output to which it
             # is referring exists
-            if register_entry.success and self.plugin_output.PluginOutputExists(register_entry.plugin_key, register_entry.target_id):
-                return self.target.GetTargetURLForID(register_entry.target_id)
-            else:  # Either command failed or plugin output doesn't exist
+            if register_entry.success:
+                if self.plugin_output.PluginOutputExists(register_entry.plugin_key, register_entry.target_id):
+                    return self.target.GetTargetURLForID(register_entry.target_id)
+                else:
+                    self.DeleteCommand(original_command)
+                    return None
+            else:  # Command failed
                 self.DeleteCommand(original_command)
                 return self.target.GetTargetURLForID(register_entry.target_id)
         return None

--- a/framework/shell/blocking_shell.py
+++ b/framework/shell/blocking_shell.py
@@ -74,8 +74,6 @@ class Shell(BaseComponent, ShellInterface):
         #return [ None, True ] # Command was not run before
         Target = self.command_register.CommandAlreadyRegistered(Command['OriginalCommand'])
         if Target:  # target_config will be None for a not found match
-            if '-f' in sys.argv:
-                return [Target, True]
             return [Target, False]
         return [None, True]
 


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
regarding force overwrite, the previous fix was limited only to CLI. This one is the proper fix which is applicable to GUI and CLI both 
## Description
<!--- Describe your changes in detail -->
IMO if the command failed or plugin output doen't exist then it should `return None` so that `CanRunCommand()` function can return True to run the given plugin.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#379 #639 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User will be able to rerun the plugin against same target from GUI as well

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@delta24 @DePierre @7a @tunnelshade 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just click on the rerun button and see the terminal, plugin should be running.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (<!--- mention here -->)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

