### PR TITLE
Show less functionality added to optimize the click flow

### DIFF
--- a/framework/interface/templates/plugin_report.html
+++ b/framework/interface/templates/plugin_report.html
@@ -130,7 +130,7 @@
                                     </tr>
                                 </tbody>
                             </table>
-                            <a style="cursor:pointer" data-code="{{ test_code }}" class="lessbtn">Show Less</p>
+                            <a style="cursor:pointer" data-code="{{ test_code }}" class="lessbtn">Collapse</p>
                         </div>
                         {% end %}
                     </div>

--- a/framework/interface/templates/plugin_report.html
+++ b/framework/interface/templates/plugin_report.html
@@ -130,6 +130,7 @@
                                     </tr>
                                 </tbody>
                             </table>
+                            <a style="cursor:pointer" data-code="{{ test_code }}" class="lessbtn">Show Less</p>
                         </div>
                         {% end %}
                     </div>
@@ -390,9 +391,21 @@ function collapsePluginOnRank() {
     });
 }
 
+// Show less Functionality
+function collapseOnShowLess() {
+    $('.lessbtn').click(function() {
+        var id = $(this).attr('data-code');
+        $('#' + id).removeClass('in');
+        $('html, body').animate({
+            scrollTop: $("#header_" + id).offset().top
+        }, 1000);
+    });
+}
+
 $(function() {
     updateTargetInfo();
     updateAllTestCasesInfo();
     collapsePluginOnRank();
+    collapseOnShowLess();
 });
 </script>


### PR DESCRIPTION
This PR is small optimization in reference to issue  #429.

## Description
Added a show less button at bottom, on clicking it Plugin gets collapse and auto scroll smoothly to plugin next to it. This will decrease a lot of vertical scrolling.

## Related Issue
#429 

## Motivation and Context
This will decrease a lot of vertical scrolling.

## Reviewers
@delta24 @7a @DePierre 

## How Has This Been Tested?
This was tested on Firefox and Chromium and works as very well on both browsers.

## Screenshots (if appropriate):
![screenshot from 2016-03-30 22-02-34](https://cloud.githubusercontent.com/assets/11960067/14149755/4d8f0de2-f6c3-11e5-8ced-0e6ef9279a7b.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.