### PR TITLE
added auxiliary plugin test group, this makes -l command functional

### DIFF
--- a/framework/config/aux_testgroups.cfg
+++ b/framework/config/aux_testgroups.cfg
@@ -1,0 +1,13 @@
+# OWASP/OWTF code + Priority + Pen tester translation + Hint + OWASP Link
+OWTF-AExP-001 | 99 | Launches all Exploits for a category(ies) | Exploit_Launcher  |  https://www.owasp.org/index.php/
+OWTF-SMB-001 | 99 | Mounts and/or uploads/downloads files to an SMB share | SMB_Handler  |  https://www.owasp.org/index.php/
+OWTF-ABrF-001 | 99 | Password Bruteforce Testing plugin | Password_Bruteforce  |  https://www.owasp.org/index.php/
+OWTF-ADoS-001 | 99 | Denial of Service (DoS) Launcher  | Direct_DoS_Launcher  |  https://www.owasp.org/index.php/
+OWTF-AWAF-001 | 99 | WAF byppaser module plugin |  WAF_Byppaser  |  https://www.owasp.org/index.php/
+OWTF-ASEP-001 | 99 | Spear Phishing Testing plugin | Spear_Phishing  |  https://www.owasp.org/index.php/
+OWTF-ASEP-002 | 99 | Targeted Phishing Testing plugin | Targeted_Phishing  |  https://www.owasp.org/index.php/
+OWTF-ARCE-001 | 99 | Runs commands on an agent server via SSH | SSH_Commander  |  https://www.owasp.org/index.php/
+OWTF-ARCE-002 | 99 | Runs commands on an agent server via SBD  | SBD_Commander  |  https://www.owasp.org/index.php/
+OWTF-ARCE-003 | 99 | Runs a chain of commands on an agent server via SBD |  SBD_CommandChainer  |  https://www.owasp.org/index.php/
+OWTF-ARCE-004 | 99 | Runs a chain of commands on an agent server via SB |  BASH_CommandChainer  |  https://www.owasp.org/index.php/
+OWTF-ASEL-001 | 99 | Sends a bunch of URLs through selenium |  Selenium_URL_Launcher  |  https://www.owasp.org/index.php/

--- a/framework/config/framework_config.cfg
+++ b/framework/config/framework_config.cfg
@@ -31,6 +31,7 @@ ZAP_PROXY_PORT: 8090
 INSTALL_SCRIPT: @@@FRAMEWORK_DIR@@@/install/install.py
 WEB_TEST_GROUPS: @@@FRAMEWORK_DIR@@@/framework/config/web_testgroups.cfg
 NET_TEST_GROUPS: @@@FRAMEWORK_DIR@@@/framework/config/net_testgroups.cfg
+AUX_TEST_GROUPS: @@@FRAMEWORK_DIR@@@/framework/config/aux_testgroups.cfg
 PLUGINS_DIR: @@@FRAMEWORK_DIR@@@/plugins/
 
 

--- a/framework/config/net_testgroups.cfg
+++ b/framework/config/net_testgroups.cfg
@@ -1,4 +1,4 @@
-# OWASP/OWTF code + Pen tester translation + OWASP Link
+# OWASP/OWTF code + Priority + Pen tester translation + Hint + OWASP Link
 PTES-001 | 99 | Probing for Ftp service | Metasploit  |  http://www.pentest-standard.org/index.php/PTES_Technical_Guidelines
 PTES-002 | 99 | Probing for Smtp service | Metasploit  |  http://www.pentest-standard.org/index.php/PTES_Technical_Guidelines
 PTES-003 | 99 | Probing for Vnc service | Metasploit  |  http://www.pentest-standard.org/index.php/PTES_Technical_Guidelines

--- a/framework/config/web_testgroups.cfg
+++ b/framework/config/web_testgroups.cfg
@@ -1,4 +1,4 @@
-# OWASP/OWTF code + Priority + Pen tester translation + OWASP Link
+# OWASP/OWTF code + Priority + Pen tester translation + Hint + OWASP Link
 OWTF-IG-001 | 99 | Spiders, Robots, and Crawlers | robots.txt Analysis | https://www.owasp.org/index.php/Testing:_Spiders,_Robots,_and_Crawlers_(OWASP-IG-001)
 OWTF-IG-002 | 99 | Search engine discovery/reconnaissance | Google Hacking, Metadata | https://www.owasp.org/index.php/Testing:_Search_engine_discovery/reconnaissance_(OWASP-IG-002)
 OWTF-IG-003 | 99 | Identify application entry points | Crawling | https://www.owasp.org/index.php/Testing:_Identify_application_entry_points_(OWASP-IG-003)


### PR DESCRIPTION
This pull request will fix -l option for auxiliary plugins. 

## Description
In this a test group file is added which contains information about all the auxiliary plugins. The corresponding function is modified in `plugin_manager.py` to load them in db.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This fixes issue #647 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will fix the problem of not listing the available aux plugin in OWTF

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@delta24 @DePierre 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test the working of this pull request run `./owtf.py -l auxiliary`

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->
![screenshot from 2016-04-01 00 43 37](https://cloud.githubusercontent.com/assets/6971456/14201760/7ea9947a-f811-11e5-82d0-7c96520fd742.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

