### PR TITLE
Dirbuster plugin working fixes #642

### DIFF
--- a/plugins/web/active/Old_Backup_and_Unreferenced_Files@OWTF-CM-006.py
+++ b/plugins/web/active/Old_Backup_and_Unreferenced_Files@OWTF-CM-006.py
@@ -12,6 +12,8 @@ def run(PluginInfo):
 	# DirBuster allows much more control when interactive
 	# DirBuster can also be run non-interactively for scripting
 	DirBusterInteraction = { 'true' : 'DirBusterInteractive', 'false' : 'DirBusterNotInteractive' }
-	return ServiceLocator.get_component("plugin_helper").CommandDump('Test Command', 'Output', ServiceLocator.get_component("resource").GetResourceList([ DirBusterInteraction[ServiceLocator.get_component("db_config").Get('INTERACTIVE')], 'DirBuster_Extract_URLs' ]), PluginInfo, [])
+	Content = ServiceLocator.get_component("plugin_helper").CommandDump('Test Command', 'Output', ServiceLocator.get_component("resource").GetResources(DirBusterInteraction[ServiceLocator.get_component("db_config").Get('INTERACTIVE')]), PluginInfo, [])
+	Content += ServiceLocator.get_component("plugin_helper").CommandDump('Test Command', 'Output', ServiceLocator.get_component("resource").GetResources('DirBuster_Extract_URLs'), PluginInfo, [])
+	return Content
 	#return ServiceLocator.get_component("plugin_helper").DrawCommandDump('Test Command', 'Output', ServiceLocator.get_component("config").GetResources(DirBusterInteraction[ServiceLocator.get_component("config").Get('Interactive')]), PluginInfo, Content)
 


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of giving the command through a list (due to which commands don't run in order ), I am giving them one by one.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#642 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Dirbuster plugin will be working by now

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@delta24 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the dirbuster plugin and now commands ran in order and hence there was no such error like `Dirbuster.txt not found`

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->
Screenshot shows that commands ran in order
![screenshot 81](https://cloud.githubusercontent.com/assets/10975138/14203337/0d902efc-f81b-11e5-8f9e-311a778a4bbb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

