### PR TITLE
Progress Bar Bug Fixed. Fixes #644

### DIFF
--- a/framework/interface/templates/manager_interface.html
+++ b/framework/interface/templates/manager_interface.html
@@ -232,6 +232,7 @@ function moveProgressBar() {
                 elem.css("width", percentage_done + '%');
                 if (percentage_done == 100) {
                     elem.removeClass('active');
+                    $('#progressbar').html('<p>Worklist is empty</p>');
                     clearInterval(progressbar);
                 }
             }

--- a/framework/interface/templates/manager_interface.html
+++ b/framework/interface/templates/manager_interface.html
@@ -19,9 +19,11 @@
     </div>
 </div>
 <br>
-<h5><strong>Progress of Running Plugins</strong></h5>
-<div class="progress">
-  <div id="pluginprogress" class="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
+<h5><strong>Total scan progress</strong></h5>
+<div id="progressbar">
+  <div class="progress">
+    <div id="pluginprogress" class="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
+    </div>
   </div>
 </div>
 <div class="row" id="workersInfo">
@@ -170,6 +172,26 @@ function getElapsedTime(start_time){
     return s;
 }
 
+// Function which checks for last task completion
+function checkForLastTaskCompletion() {
+    var flag = true;
+    $.ajax({
+        url: mySpace.workers_api_url,
+        ifModified: true,
+        dataType: 'json',
+        async: false,
+        success: function(data) {
+            $.each(data, function(index, obj) {
+                if (obj.busy) {
+                    flag = false;
+                    return false;
+                }
+            });
+        }
+    });
+    return flag;
+}
+
 //Function which updates progress bar
 function moveProgressBar() {
     var elem = $("#pluginprogress");
@@ -177,11 +199,22 @@ function moveProgressBar() {
         $.getJSON(mySpace.plugins_api_url + 'progress/', function(data) {
             var left_count = data.left_count;
             var complete_count = data.complete_count;
-            percentage_done = (complete_count / (left_count + complete_count)) * 100;
-            elem.css("width", percentage_done + '%');
-            if (percentage_done == 100) {
-                elem.removeClass('active');
+            left_count++;
+            if (left_count == 1) {
+                if (checkForLastTaskCompletion()) {
+                    left_count--;
+                }
+            }
+            if (left_count == 0 && complete_count == 0) {
+                $('#progressbar').html('<p>You have not added anything to worklist yet</p>');
                 clearInterval(progressbar);
+            } else {
+                percentage_done = (complete_count / (left_count + complete_count)) * 100;
+                elem.css("width", percentage_done + '%');
+                if (percentage_done == 100) {
+                    elem.removeClass('active');
+                    clearInterval(progressbar);
+                }
             }
         });
     }, 1000);

--- a/framework/interface/templates/manager_interface.html
+++ b/framework/interface/templates/manager_interface.html
@@ -192,6 +192,25 @@ function checkForLastTaskCompletion() {
     return flag;
 }
 
+// Function which returns the number of busy workers
+function getBusyWorkers() {
+    var count = 0;
+    $.ajax({
+        url: mySpace.workers_api_url,
+        ifModified: true,
+        dataType: 'json',
+        async: false,
+        success: function(data) {
+            $.each(data, function(index, obj) {
+                if (obj.busy) {
+                    count++;
+                }
+            });
+        }
+    });
+    return count;
+}
+
 //Function which updates progress bar
 function moveProgressBar() {
     var elem = $("#pluginprogress");
@@ -199,7 +218,7 @@ function moveProgressBar() {
         $.getJSON(mySpace.plugins_api_url + 'progress/', function(data) {
             var left_count = data.left_count;
             var complete_count = data.complete_count;
-            left_count++;
+            left_count += getBusyWorkers();
             if (left_count == 1) {
                 if (checkForLastTaskCompletion()) {
                     left_count--;


### PR DESCRIPTION
This PR fixes the progress bar bugs referenced in #644

## Description
Fix of Bug-1 : To fix this bug, PR checks left_count == 0 and complete count == 0 and if it is true, It just replaces the progress bar with simple message.
Fix of Bug-2 : To fix this bug, PR increases the left_count by 1 because what was happening previously that if the plugin was running it assumed to be completed as it is was removed from work-list. Also at condition where left_count=1. PR checks the busy attribute of every worker and if no worker is running PR decreases the left_count by 1. Hence this fixes Bug-2
  
## Related Issue
#644 

## Reviewers
@delta24 @DePierre @DoomTaper @7a 

## How Has This Been Tested?
Tested on Firefox and Chrome, working on both the browsers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.