### PR TITLE
set plugin group according to type if possible, fixes #390

### DIFF
--- a/framework/config/config.py
+++ b/framework/config/config.py
@@ -150,8 +150,8 @@ class Config(BaseComponent, ConfigInterface):
 
         """
         target = self.target.GetTargetConfigs({'target_url': target_url})
+        group = options['PluginGroup']
         if options['OnlyPlugins'] is None:
-            group = options['PluginGroup']
             # If the plugin group option is the default one (not specified by
             # the user).
             if group is None:
@@ -168,6 +168,9 @@ class Config(BaseComponent, ConfigInterface):
                 "code": options.get("OnlyPlugins"),
                 "type": options.get("PluginType")}
         plugins = self.db_plugin.GetAll(filter_data)
+        if not plugins:
+            logging.error("No plugin found matching type %s and group '%s' for %s target"
+                          % (options['PluginType'], group, target[0]['top_url']))
         self.worklist_manager.add_work(
             target,
             plugins,

--- a/owtf.py
+++ b/owtf.py
@@ -55,6 +55,7 @@ def process_options(user_args):
     # Default settings:
     profiles = {}
     plugin_group = arg.PluginGroup
+
     if arg.CustomProfile:  # Custom profiles specified
         # Quick pseudo-validation check
         for profile in arg.CustomProfile.split(','):
@@ -141,18 +142,11 @@ def process_options(user_args):
             except ValueError:
                 usage("Invalid port for Inbound Proxy")
 
-    plugin_types_for_group = ServiceLocator.get_component("db_plugin").GetTypesForGroup(plugin_group)
+    plugin_types_for_group = db_plugin.GetTypesForGroup(plugin_group)
     if arg.PluginType == 'all':
         arg.PluginType = plugin_types_for_group
     elif arg.PluginType == 'quiet':
         arg.PluginType = ['passive', 'semi_passive']
-        if plugin_group != 'web':
-            usage("The quiet plugin type is only for the web plugin group")
-    elif arg.PluginType not in plugin_types_for_group:
-        usage(
-            "Invalid Plugin Type '" + str(arg.PluginType) +
-            "' for Plugin Group '" + str(plugin_group) +
-            "'. Valid Types: " + ', '.join(plugin_types_for_group))
 
     scope = arg.Targets or []  # Arguments at the end are the URL target(s)
     num_targets = len(scope)


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
This PR sets the plugin group according to the plugin_type. This makes -t command functional.

## Description
<!--- Describe your changes in detail -->
Set the plugin_group according to type requested using `-t` option.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#390 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@delta24 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
./owtf.py -t passive

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->
![screenshot from 2016-04-14 11 33 19](https://cloud.githubusercontent.com/assets/6971456/14518370/d437224a-0234-11e6-9bed-b1c64448fa89.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

