### PR TITLE
Addded plugin name to code converter function Fixes #650

### DIFF
--- a/framework/db/plugin_manager.py
+++ b/framework/db/plugin_manager.py
@@ -212,7 +212,17 @@ class PluginDB(BaseComponent, DBPluginInterface):
                 query = query.filter(models.Plugin.name.in_(criteria["name"]))
         return query.order_by(models.TestGroup.priority.desc())
 
+    def PluginNametoCode(self, codes):
+        query = self.db.session.query(models.Plugin.code)
+        for count, name in enumerate(codes):
+            if "OWTF-" not in name:
+                code = query.filter(models.Plugin.name == name).first()
+                codes[count] = str(code[0])
+        return(codes)
+
     def GetAll(self, Criteria={}):
+        if Criteria.has_key("code"):
+            Criteria["code"] = self.PluginNametoCode(Criteria["code"])
         query = self.GenerateQueryUsingSession(Criteria)
         plugin_obj_list = query.all()
         return(self.DerivePluginDicts(plugin_obj_list))


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added plugin name to code converter function so that before querying all plugin names are converted to their respective codes

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#650 

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@delta24 @DePierre 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested command `./owtf.py -o Application_Discovery http://127.0.0.1`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

