### PR TITLE
[ui] Added javascript function to check selected session, Fixes #608

### DIFF
--- a/framework/interface/templates/target_manager.html
+++ b/framework/interface/templates/target_manager.html
@@ -280,6 +280,22 @@ function activateSession(session_id) {
     });
 }
 
+// This function will be called when the session modal closes
+$('#sessionModal').on('hidden.bs.modal', function () {
+    if ($('input[name=session_id]:checked').length > 0){
+        // The session is selected. Nothing to do in this case
+        return;
+    }
+    if($('input[name=session_id]').length == 1){
+        // If only one session is found in the db, then choose that by default.
+        activateSession($('input[name=session_id]').val());
+    } else{
+        // Alert the user for not selecting any session
+        $("#sessionName").val("No session selected :(");
+        alertFail(" No active action session found. Please select a session");
+    }
+});
+
 // Function that adds targets to the target list(table infact)
 function addSessions(data, status, xhr) {
     jQuery('#sessionTable').dataTable().fnClearTable();

--- a/framework/interface/templates/target_manager.html
+++ b/framework/interface/templates/target_manager.html
@@ -278,17 +278,19 @@ function activateSession(session_id) {
             alertFail("Server replied: "+serverResponse);
             }
     });
+    $('#sessionModal').modal('hide');
 }
 
 // This function will be called when the session modal closes
 $('#sessionModal').on('hidden.bs.modal', function () {
-    if ($('input[name=session_id]:checked').length > 0){
+    var radio_session = $('input:radio[name="session_id"]');
+    if (radio_session.is(':checked') > 0){
         // The session is selected. Nothing to do in this case
         return;
     }
-    if($('input[name=session_id]').length == 1){
+    if(radio_session.length == 1){
         // If only one session is found in the db, then choose that by default.
-        activateSession($('input[name=session_id]').val());
+        activateSession(radio_session.val());
     } else{
         // Alert the user for not selecting any session
         $("#sessionName").val("No session selected :(");
@@ -304,7 +306,7 @@ function addSessions(data, status, xhr) {
         actionButtons = '<a href="#" onclick="deleteSession('+obj.id+');" data-toggle="tooltip" data-placement="bottom" title="Delete session">';
         actionButtons += '<span class="btn btn-xs btn-danger"><i class="fa fa-times"></i></span></a>'
         jQuery('#sessionTable').dataTable().fnAddData([
-            '<input type="radio" name="session_id" data-dismiss="modal" onclick="activateSession('+obj.id+');" value="'+obj.id+'" '+checked+'>',
+            '<input type="radio" name="session_id" onclick="activateSession('+obj.id+');" value="'+obj.id+'" '+checked+'>',
             escapeHtml(obj.name),
             actionButtons
         ]);


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
Added a js function which is called whenever the session model is closed.

## Description
<!--- Describe your changes in detail -->
* If a session is selected, no action is taken.
* If no session is selected
 * If one one session is present, it is selected by default.
 * Else a alert message is shown to select a session.

## Related Issue
Issue #608 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Reviewers
@delta24 
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->
![screenshot from 2016-07-21 23 46 22](https://cloud.githubusercontent.com/assets/6971456/17033887/de6b2f52-4f9d-11e6-88a5-0c86bd0f46b7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

