### PR TITLE
[webui] Plugin_types buttons added on panel bar to open it directly

### DIFF
--- a/framework/interface/templates/plugin_report.html
+++ b/framework/interface/templates/plugin_report.html
@@ -3,12 +3,20 @@
         <div id="header_{{ test_code }}"class="panel panel-default">
             <div class="panel-heading" style="padding: 0 15px">
                 <div class="row">
-                    <div class="col-md-10" style="padding-left: 15px">
+                    <div class="col-md-6" style="padding-left: 15px">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" data-parent="#pluginOutputs" href="#{{ test_code }}">
                                 <h4 style="padding: 15px">{{ test_groups[test_code]['mapped_code'] }} {{ test_groups[test_code]['mapped_descrip'] }} <small>{{ test_groups[test_code]['hint'] }}</small></h4>
                             </a>
                         </h4>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="btn-group btn-group-xs" role="group">
+                            {% for poutput in poutput_list %}
+                            {% set pkey = poutput['plugin_type'] + '_' + poutput['plugin_code'] %}
+                                <button class="plugin_btn_{{ test_code }} plugin_type_acc btn" style="margin-top: 23px" type="button" data-code="{{ test_code }}" data-navtab="navtab_{{ pkey }}" data-content="{{ poutput['plugin_group'] }}__{{ poutput['plugin_type'] }}__{{ test_code }}">{{ poutput['plugin_type'].replace('_',' ').capitalize() }}</button>
+                            {% end %}
+                        </div>
                     </div>
                     <div class="col-md-2" style="text-align: center;">
                         <h4 id="header_badge_{{ test_code }}"></h4>
@@ -22,7 +30,7 @@
                         {% set pactive = 'active' if len(poutput_list) == 1 else '' %}
                         {% for poutput in poutput_list %}
                         {% set pkey = poutput['plugin_type'] + '_' + poutput['plugin_code'] %}
-                        <li class="{{ pactive }}">
+                        <li id="navtab_{{ pkey }}" class="{{ pactive }}">
                             <a id="tab_{{ pkey }}" href="#{{ poutput['plugin_group'] }}__{{ poutput['plugin_type'] }}__{{ test_code }}" data-toggle="tab">
                                 {{ poutput['plugin_type'].replace('_',' ') }}
                             </a>
@@ -349,6 +357,7 @@ function updateAllTestCasesInfo() {
         testCaseMax = (maxUserRank > maxOWTFRank) ? maxUserRank : maxOWTFRank;
         resetTestCaseColors(code);
         $("#header_" + code).toggleClass("panel-" + getAlertColor(testCaseMax));
+        $(".plugin_btn_" + code).addClass(getAlertColor(testCaseMax) === 'passing' ? "btn-default":"btn-"+getAlertColor(testCaseMax));
         $("#header_badge_" + code).css("opacity", "");
         $("#header_badge_" + code).html('<i><small>' + getLabelColor(testCaseMax) + '</small></i>');
         if (testCaseMax > maxUserRank && testCaseMax != -1)
@@ -401,6 +410,18 @@ function collapsePluginOnRank() {
 }
 
 // Show less Functionality
+function handlePluginBtnOnAccordian() {
+    $('.plugin_type_acc').click(function() {
+        var id = $(this).attr('data-code');
+        var navId = $(this).attr('data-navtab');
+        var navContentId = $(this).attr('data-content');
+        $('#' + id).collapse('show');
+        $('#' + navId).addClass('active').siblings().removeClass('active');
+        $('#' + navContentId).addClass('active').siblings().removeClass('active');
+    });
+}
+
+// Show less Functionality
 function collapseOnShowLess() {
     $('.lessbtn').click(function() {
         var id = $(this).attr('data-code');
@@ -416,5 +437,6 @@ $(function() {
     updateAllTestCasesInfo();
     collapsePluginOnRank();
     collapseOnShowLess();
+    handlePluginBtnOnAccordian();
 });
 </script>


### PR DESCRIPTION
Plugin_types buttons added on panel bar to open it directly

## Description
As a part to decrease no. of clicks to quickly review all the plugins, new buttons added on panel bar so that clicked plugin_type can directly be opened from accordian. this will -1 the clicks.

## Reviewers
@delta24 @7a @tunnelshade @anantshri 

## Screenshots (if appropriate):
![screenshot from 2016-09-01 15-36-51](https://cloud.githubusercontent.com/assets/11960067/18163853/a26df074-705a-11e6-81d9-2bb25ca5ce77.png)
![screenshot from 2016-09-01 15-36-49](https://cloud.githubusercontent.com/assets/11960067/18163854/a273fc26-705a-11e6-9591-04c42fa5bd56.png)
![screenshot from 2016-09-01 15-36-43](https://cloud.githubusercontent.com/assets/11960067/18163855/a27bf200-705a-11e6-9362-0e2aca9416f5.png)
![screenshot from 2016-09-01 15-36-32](https://cloud.githubusercontent.com/assets/11960067/18163856/a27ceac0-705a-11e6-80b0-d0ff0b36a5be.png)
![screenshot from 2016-09-01 15-36-27](https://cloud.githubusercontent.com/assets/11960067/18163857/a2810d3a-705a-11e6-8a93-9a6ad84d48db.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other
