### PR TITLE
Global severity coloring

### DIFF
--- a/framework/db/target_manager.py
+++ b/framework/db/target_manager.py
@@ -333,14 +333,15 @@ class TargetDB(BaseComponent, TargetInterface):
 
     def GetTargetsSeverityCount(self):
         filtered_severity_objs = []
+        # "not ranked" = gray, "passing" = light green?, "info" = dark green?, "low" = blue, medium = yellow, high = red, critical = dark purple
         severity_frequency = [
-            {"id":0, "label": "Not Ranked", "value": 0, "color": "#008000"},
-            {"id":1, "label": "Passing", "value": 0, "color": "#5E5D57"},
-            {"id":2, "label": "Info", "value": 0, "color": "#d6e9c6"},
-            {"id":3, "label": "Low", "value": 0, "color": "#bce8f1"},
-            {"id":4, "label": "Medium", "value": 0, "color": "#f0ad4e"},
-            {"id":5, "label": "High", "value": 0, "color": "#ebccd1"},
-            {"id":6, "label": "Critical", "value": 0, "color": "#b92c28"}
+            {"id":0, "label": "Not Ranked", "value": 0, "color": "#A9A9A9"},
+            {"id":1, "label": "Passing", "value": 0, "color": "#32CD32"},
+            {"id":2, "label": "Info", "value": 0, "color": "#006400"},
+            {"id":3, "label": "Low", "value": 0, "color": "#337ab7"},
+            {"id":4, "label": "Medium", "value": 0, "color": "#ffcc00"},
+            {"id":5, "label": "High", "value": 0, "color": "#c12e2a"},
+            {"id":6, "label": "Critical", "value": 0, "color": "#800080"}
         ]
         total = self.db.session.query(models.Target).count()
         target_objs = self.db.session.query(models.Target).all()

--- a/framework/db/target_manager.py
+++ b/framework/db/target_manager.py
@@ -333,11 +333,11 @@ class TargetDB(BaseComponent, TargetInterface):
 
     def GetTargetsSeverityCount(self):
         filtered_severity_objs = []
-        # "not ranked" = gray, "passing" = light green?, "info" = dark green?, "low" = blue, medium = yellow, high = red, critical = dark purple
+        # "not ranked" = gray, "passing" = light green, "info" = light sky blue, "low" = blue, medium = yellow, high = red, critical = dark purple
         severity_frequency = [
             {"id":0, "label": "Not Ranked", "value": 0, "color": "#A9A9A9"},
             {"id":1, "label": "Passing", "value": 0, "color": "#32CD32"},
-            {"id":2, "label": "Info", "value": 0, "color": "#006400"},
+            {"id":2, "label": "Info", "value": 0, "color": "#b1d9f4"},
             {"id":3, "label": "Low", "value": 0, "color": "#337ab7"},
             {"id":4, "label": "Medium", "value": 0, "color": "#ffcc00"},
             {"id":5, "label": "High", "value": 0, "color": "#c12e2a"},

--- a/includes/css/stylesheet.css
+++ b/includes/css/stylesheet.css
@@ -46,23 +46,24 @@ body {
 }
 
 .panel-critical > .panel-heading, .alert-critical {
-    background-image: linear-gradient(to bottom, #d9534f 0px, #c12e2a 100%);
+    background-image: linear-gradient(to bottom, #E6E6FA 0px, #E6E6FA 100%);
     background-repeat: repeat-x;
-    border-color: #b92c28;
-    color: #fff;
+    border-color: #BDA0CB;
+    color: #800080;
 }
 
 .btn-critical {
-    background-image: linear-gradient(to bottom, #d9534f 0px, #c12e2a 100%);
-    background-repeat: repeat-x;
-    border-color: #b92c28;
+    color: #fff;
+    background-color: #800080;
+    border-color: #551A8B;
+    text-decoration: none;
 }
 
-.btn-critical:active, .btn-critical.active {
-    background-color: #c12e2a;
-    border-color: #b92c28;
+.btn-critical:active, .btn-critical:hover {
     color: #fff;
-    box-shadow: 0 3px 5px rgba(0, 0, 0, 0.125) inset;
+    background-color: #800080;
+    border-color: #551A8B;
+    text-decoration: none;
 }
 
 .panel-passing > .panel-heading, .alert-passing, .label-passing, .btn-passive:active, .btn-passing.active {

--- a/includes/css/stylesheet.css
+++ b/includes/css/stylesheet.css
@@ -189,12 +189,13 @@ body {
 }
 
 /* CSS Belongs to Vulnerability Panel */
+/* "not ranked" = gray, "passing" = light green?, "info" = dark green?, "low" = blue, medium = yellow, high = red, critical = dark purple */
 .sevpanel-critical {
-  background-color: #c12e2a;
+  background-color: #800080;
 }
 
 .sevpanel-high {
-  background-color: #FF9900;
+  background-color: #c12e2a;
 }
 
 .sevpanel-medium {
@@ -202,15 +203,15 @@ body {
 }
 
 .sevpanel-low {
-  background-color: green;
-}
-
-.sevpanel-info {
   background-color: #337ab7;
 }
 
+.sevpanel-info {
+  background-color: #006400;
+}
+
 .sevpanel-passing {
-  background-color: #808080;
+  background-color: #32CD32;
 }
 
 .sevpanel {

--- a/includes/css/stylesheet.css
+++ b/includes/css/stylesheet.css
@@ -190,7 +190,7 @@ body {
 }
 
 /* CSS Belongs to Vulnerability Panel */
-/* "not ranked" = gray, "passing" = light green?, "info" = dark green?, "low" = blue, medium = yellow, high = red, critical = dark purple */
+/* "not ranked" = gray, "passing" = light green, "info" = light sky blue, "low" = blue, medium = yellow, high = red, critical = dark purple */
 .sevpanel-critical {
   background-color: #800080;
 }
@@ -208,7 +208,7 @@ body {
 }
 
 .sevpanel-info {
-  background-color: #006400;
+  background-color: #b1d9f4;
 }
 
 .sevpanel-passing {


### PR DESCRIPTION
As suggested by @7a , This PR globally apply colors for severity.
Colors are as follow:
"not ranked" = gray, "passing" = light green?, "info" = dark green?, "low" = blue, medium = yellow, high = red, critical = dark purple

## Reviewers
@delta24 @7a 


## Screenshots (if appropriate):
![screenshot from 2016-09-11 13-13-23](https://cloud.githubusercontent.com/assets/11960067/18415933/bc87ce84-7821-11e6-873e-2f3ba6983cf2.png)
![screenshot from 2016-09-11 13-13-08](https://cloud.githubusercontent.com/assets/11960067/18415934/bc8c96ee-7821-11e6-8920-edac49ee6dec.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other
