### PR TITLE
[webui] React bundle build at the start of owtf

### DIFF
--- a/owtf.py
+++ b/owtf.py
@@ -193,6 +193,9 @@ def process_options(user_args):
         'Args': args
     }
 
+def build_react_bundle():
+    print("\033[93m[*] Building the react bundle. Plese wait..")
+    os.system("npm run build > /dev/null")
 
 def run_owtf(core, args):
     try:
@@ -234,6 +237,7 @@ def main(args):
                 ServiceLocator.get_component("config").FrameworkConfigGet('VERSION'),
                 ServiceLocator.get_component("config").FrameworkConfigGet('RELEASE'))
         )
+        build_react_bundle()
         run_owtf(core, args)
     else:
         # First confirming that --update flag is present in args and then


### PR DESCRIPTION
This will make owtf.py to build the bundle when owtf start.

## Reviewers
@delta24 @7a 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other

