### PR TITLE
[install] CMS explorer download link changed.

### DIFF
--- a/install/distro-independent.cfg
+++ b/install/distro-independent.cfg
@@ -55,7 +55,7 @@ command = sh %(RootDir)s/install/install_zest_jars.sh
 
 [CMS Explorer]
 directory = %(RootDir)s/tools/restricted/cms-explorer
-command = wget --user-agent="Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/15.0" --tries=3 http://cms-explorer.googlecode.com/files/cms-explorer-1.0.tar.bz2; bunzip2 *; tar xvf *; rm -f *.tar 2> /dev/null; sh %(RootDir)s/install/update_convert_cms_explorer_dicts.sh %(RootDir)s
+command = wget --user-agent="Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/15.0" --tries=3  https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cms-explorer/cms-explorer-1.0.tar.bz2; bunzip2 *; tar xvf *; rm -f *.tar 2> /dev/null; sh %(RootDir)s/install/update_convert_cms_explorer_dicts.sh %(RootDir)s
 
 [SVN Digger Dictionaries]
 directory = %(RootDir)s/dictionaries/restricted/svndigger


### PR DESCRIPTION
Currently the link is broken and it returns 404.

## Description
This issue arises on installing OWTF. Currently the link is broken and it returns 404.

## Related Issue
#745 

## Reviewers
@delta24 @7a @anantshri 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

