### PR TITLE
[webui] Removes recently finished targets polling to improve preformance

### DIFF
--- a/framework/interface/templates/base.html
+++ b/framework/interface/templates/base.html
@@ -124,29 +124,6 @@
         $(selector).prop("disabled", true);
     }
 
-    // Function that fills the recently completed targets
-    function recentlyFinishedTargets() {
-        $.ajax({url: '/api/targets/recent/',
-                ifModified: true,
-                dataType:'json',
-                success:function(json, textStatus, jqXHR){
-                    if (304 != jqXHR.status){
-                        data = json.data
-                        $('#target_dropdown').empty();
-                        $('#target_dropdown').append(
-                          $('<li>').attr('class','dropdown-header').append("Recently Finished(" + data.length.toString() + ")" )
-                        );
-                        for(var i = 0; i < data.length; i++) {
-                            var obj = data[i];
-                            $('#target_dropdown').append(
-                                $('<li>').append($('<a>').attr('href','/ui/targets/' + obj.target_id).append(obj.target_url))
-                            );
-                          }
-                        };
-                    }
-        });
-    }
-
     </script>
     <!-- End status box message -->
 
@@ -171,14 +148,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav navbar-right">
                     <li><a href="{{ reverse_url('dashboard_ui_url') }}"><i class="fa fa-tachometer"></i> Dashboard</a></li>
-                    <li>
-                        <a href="{{ reverse_url('targets_ui_url', None) }}" class="target-tab"><i class="fa fa-crosshairs"></i> Targets</a>
-                        <button type="button" class="btn btn-target dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                          <span class="caret"></span>
-                          <span class="sr-only">Toggle Dropdown</span>
-                        </button>
-                        <ul class="dropdown-menu" id="target_dropdown"></ul>
-                    </li>
+                    <li><a href="{{ reverse_url('targets_ui_url', None) }}" class="target-tab"><i class="fa fa-crosshairs"></i> Targets</a></li>
                     <li><a href="{{ reverse_url('workers_ui_url', None) }}"><i class="fa fa-th-large"></i> Workers</a></li>
                     <li><a href="{{ reverse_url('worklist_ui_url') }}"><i class="fa fa-bars"></i> Worklist</a></li>
                     <li><a href="{{ reverse_url('configuration_ui_url') }}"><i class="fa fa-gears"></i> Settings</a></li>

--- a/framework/interface/templates/base.html
+++ b/framework/interface/templates/base.html
@@ -145,7 +145,6 @@
                         };
                     }
         });
-        setTimeout(recentlyFinishedTargets, 3000);
     }
 
     </script>


### PR DESCRIPTION
Removes recently finished targets polling to improve performance

## Description
This is done because polling this endpoint is not much of importance and also it keeps server busy and hence decreases the performance.

## Reviewers
@delta24 @7a 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

