### PR TITLE
Report fixes

### DIFF
--- a/framework/db/poutput_manager.py
+++ b/framework/db/poutput_manager.py
@@ -113,6 +113,15 @@ class POutputDB(BaseComponent, PluginOutputInterface):
             raise InvalidParameterType("Integer has to be provided for integer fields")
         if not for_delete:
             query = query.order_by(models.PluginOutput.plugin_key.asc())
+        try:
+            if filter_data.get("offset", None):
+                if isinstance(filter_data.get("offset"), list):
+                    query = query.offset(int(filter_data["offset"][0]))
+            if filter_data.get("limit", None):
+                if isinstance(filter_data.get("limit"), list):
+                    query = query.limit(int(filter_data["limit"][0]))
+        except ValueError:
+            raise InvalidParameterType("Integer has to be provided for integer fields")
         return query
 
     @target_required

--- a/includes/src/Report/Accordians.js
+++ b/includes/src/Report/Accordians.js
@@ -6,7 +6,12 @@ class Accordians extends React.Component {
     constructor(props) {
         super(props);
 
+        this.state = {
+            pactive: {}
+        };
+
         this.getRank = this.getRank.bind(this);
+        this.handlePluginBtnOnAccordian = this.handlePluginBtnOnAccordian.bind(this);
     };
 
     getRank(pluginDataList) {
@@ -20,14 +25,14 @@ class Accordians extends React.Component {
         var selectedStatus = this.context.selectedStatus;
 
         for (var i = 0; i < pluginDataList.length; i++) {
-            if ((selectedType.length === 0 || selectedType.indexOf(pluginDataList[i].plugin_type) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(pluginDataList[i].plugin_group) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(pluginDataList[i].user_rank) !== -1) && (selectedOwtfRank.length === 0 || selectedOwtfRank.indexOf(pluginDataList[i].owtf_rank) !== -1) && (selectedStatus.length === 0 || selectedStatus.indexOf(pluginDataList[i].status) !== -1)) {
-                if (pluginDataList[i].user_rank != null && pluginDataList[i].user_rank != -1) {
-                    if (pluginDataList[i].user_rank > maxUserRank) {
-                        maxUserRank = pluginDataList[i].user_rank;
+            if ((selectedType.length === 0 || selectedType.indexOf(pluginDataList[i]['plugin_type']) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(pluginDataList[i]['plugin_group']) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(pluginDataList[i]['user_rank']) !== -1) && (selectedOwtfRank.length === 0 || selectedOwtfRank.indexOf(pluginDataList[i]['owtf_rank']) !== -1) && (selectedStatus.length === 0 || selectedStatus.indexOf(pluginDataList[i]['status']) !== -1)) {
+                if (pluginDataList[i]['user_rank'] != null && pluginDataList[i]['user_rank'] != -1) {
+                    if (pluginDataList[i]['user_rank'] > maxUserRank) {
+                        maxUserRank = pluginDataList[i]['user_rank'];
                     }
-                } else if (pluginDataList[i].owtf_rank != null && pluginDataList[i].owtf_rank != -1) {
-                    if (pluginDataList[i].owtf_rank > maxOWTFRank) {
-                        maxOWTFRank = pluginDataList[i].owtf_rank;
+                } else if (pluginDataList[i]['owtf_rank'] != null && pluginDataList[i]['owtf_rank'] != -1) {
+                    if (pluginDataList[i]['owtf_rank'] > maxOWTFRank) {
+                        maxOWTFRank = pluginDataList[i]['owtf_rank'];
                     }
                 }
             }
@@ -38,16 +43,27 @@ class Accordians extends React.Component {
         return testCaseMax;
     };
 
+    handlePluginBtnOnAccordian(key, plugin_type) {
+        var presentPactive = this.state.pactive;
+        presentPactive[key] = plugin_type;
+        this.setState({
+            pactive: presentPactive
+        }, function() {
+            $('#' + key).collapse('show');
+        });
+    };
+
     render() {
+        var pactive = this.state.pactive;
         var plugins = this.context.pluginNameData;
         var pluginData = this.context.pluginData;
         var getRank = this.getRank;
-        var handlePluginBtnOnAccordian = this.context.handlePluginBtnOnAccordian;
         var selectedType = this.context.selectedType;
         var selectedRank = this.context.selectedRank;
         var selectedGroup = this.context.selectedGroup;
         var selectedOwtfRank = this.context.selectedOwtfRank;
         var selectedStatus = this.context.selectedStatus;
+        var handlePluginBtnOnAccordian = this.handlePluginBtnOnAccordian;
 
         return (
             <div className="panel-group" id="pluginOutputs">
@@ -158,7 +174,7 @@ class Accordians extends React.Component {
                             </div>
                             {(() => {
                                 if (key in pluginData) {
-                                    return (<Collapse pluginData={pluginData[key]} plugin={plugins[key]}/>);
+                                    return (<Collapse pluginData={pluginData[key]} plugin={plugins[key]} pactive={pactive.hasOwnProperty(key) ? pactive[key] : (pluginData[key].length > 0 ? pluginData[key][0]['plugin_type'] : null) }/>);
                                 }
                             })()}
                         </div>
@@ -177,7 +193,6 @@ Accordians.contextTypes = {
     selectedGroup: React.PropTypes.array,
     selectedOwtfRank: React.PropTypes.array,
     selectedStatus: React.PropTypes.array,
-    handlePluginBtnOnAccordian: React.PropTypes.func
 };
 
 export default Accordians;

--- a/includes/src/Report/Accordians.js
+++ b/includes/src/Report/Accordians.js
@@ -3,18 +3,32 @@ import Collapse from './Collapse'
 
 class Accordians extends React.Component {
 
+    constructor(props) {
+        super(props);
+
+        this.getRank = this.getRank.bind(this);
+    };
+
     getRank(pluginDataList) {
         var testCaseMax = 0;
         var maxUserRank = -1;
         var maxOWTFRank = -1;
+        var selectedType = this.context.selectedType;
+        var selectedRank = this.context.selectedRank;
+        var selectedGroup = this.context.selectedGroup;
+        var selectedOwtfRank = this.context.selectedOwtfRank;
+        var selectedStatus = this.context.selectedStatus;
+
         for (var i = 0; i < pluginDataList.length; i++) {
-            if (pluginDataList[i].user_rank != null && pluginDataList[i].user_rank != -1) {
-                if (pluginDataList[i].user_rank > maxUserRank) {
-                    maxUserRank = pluginDataList[i].user_rank;
-                }
-            } else if (pluginDataList[i].owtf_rank != null && pluginDataList[i].owtf_rank != -1) {
-                if (pluginDataList[i].owtf_rank > maxOWTFRank) {
-                    maxOWTFRank = pluginDataList[i].owtf_rank;
+            if ((selectedType.length === 0 || selectedType.indexOf(pluginDataList[i].plugin_type) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(pluginDataList[i].plugin_group) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(pluginDataList[i].user_rank) !== -1) && (selectedOwtfRank.length === 0 || selectedOwtfRank.indexOf(pluginDataList[i].owtf_rank) !== -1) && (selectedStatus.length === 0 || selectedStatus.indexOf(pluginDataList[i].status) !== -1)) {
+                if (pluginDataList[i].user_rank != null && pluginDataList[i].user_rank != -1) {
+                    if (pluginDataList[i].user_rank > maxUserRank) {
+                        maxUserRank = pluginDataList[i].user_rank;
+                    }
+                } else if (pluginDataList[i].owtf_rank != null && pluginDataList[i].owtf_rank != -1) {
+                    if (pluginDataList[i].owtf_rank > maxOWTFRank) {
+                        maxOWTFRank = pluginDataList[i].owtf_rank;
+                    }
                 }
             }
         }
@@ -29,6 +43,11 @@ class Accordians extends React.Component {
         var pluginData = this.context.pluginData;
         var getRank = this.getRank;
         var handlePluginBtnOnAccordian = this.context.handlePluginBtnOnAccordian;
+        var selectedType = this.context.selectedType;
+        var selectedRank = this.context.selectedRank;
+        var selectedGroup = this.context.selectedGroup;
+        var selectedOwtfRank = this.context.selectedOwtfRank;
+        var selectedStatus = this.context.selectedStatus;
 
         return (
             <div className="panel-group" id="pluginOutputs">
@@ -66,29 +85,31 @@ class Accordians extends React.Component {
                                                 <div className="col-md-2">
                                                     <div className="btn-group btn-group-xs" role="group">
                                                         {pluginData[key].map(function(obj) {
-                                                            return (
-                                                                <button onClick={handlePluginBtnOnAccordian.bind(this, key, obj['plugin_type'])} key={key + obj['plugin_type'].split('_').join(' ')} className={(() => {
-                                                                    if (key in pluginData) {
-                                                                        if (testCaseMax == 0)
-                                                                            return "btn btn-default";
-                                                                        else if (testCaseMax === 1)
-                                                                            return "btn btn-success";
-                                                                        else if (testCaseMax === 2)
-                                                                            return "btn btn-info";
-                                                                        else if (testCaseMax === 3)
-                                                                            return "btn btn-warning";
-                                                                        else if (testCaseMax === 4)
-                                                                            return "btn btn-danger";
-                                                                        else if (testCaseMax === 5)
-                                                                            return "btn btn-critical";
-                                                                        return "btn btn-unranked";
-                                                                    } else {
-                                                                        return "btn";
-                                                                    }
-                                                                })()} style={{
-                                                                    marginTop: "23px"
-                                                                }} type="button">{obj['plugin_type'].split('_').join(' ').charAt(0).toUpperCase() + obj['plugin_type'].split('_').join(' ').slice(1)}</button>
-                                                            );
+                                                            if ((selectedType.length === 0 || selectedType.indexOf(obj['plugin_type']) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(obj['plugin_group']) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(obj['user_rank']) !== -1) && (selectedOwtfRank.length === 0 || selectedOwtfRank.indexOf(obj['owtf_rank']) !== -1) && (selectedStatus.length === 0 || selectedStatus.indexOf(obj['status']) !== -1)) {
+                                                                return (
+                                                                    <button onClick={handlePluginBtnOnAccordian.bind(this, key, obj['plugin_type'])} key={key + obj['plugin_type'].split('_').join(' ')} className={(() => {
+                                                                        if (key in pluginData) {
+                                                                            if (testCaseMax == 0)
+                                                                                return "btn btn-default";
+                                                                            else if (testCaseMax === 1)
+                                                                                return "btn btn-success";
+                                                                            else if (testCaseMax === 2)
+                                                                                return "btn btn-info";
+                                                                            else if (testCaseMax === 3)
+                                                                                return "btn btn-warning";
+                                                                            else if (testCaseMax === 4)
+                                                                                return "btn btn-danger";
+                                                                            else if (testCaseMax === 5)
+                                                                                return "btn btn-critical";
+                                                                            return "btn btn-unranked";
+                                                                        } else {
+                                                                            return "btn";
+                                                                        }
+                                                                    })()} style={{
+                                                                        marginTop: "23px"
+                                                                    }} type="button">{obj['plugin_type'].split('_').join(' ').charAt(0).toUpperCase() + obj['plugin_type'].split('_').join(' ').slice(1)}</button>
+                                                                );
+                                                            }
                                                         })}
                                                     </div>
                                                 </div>
@@ -151,6 +172,11 @@ class Accordians extends React.Component {
 Accordians.contextTypes = {
     pluginNameData: React.PropTypes.object,
     pluginData: React.PropTypes.object,
+    selectedType: React.PropTypes.array,
+    selectedRank: React.PropTypes.array,
+    selectedGroup: React.PropTypes.array,
+    selectedOwtfRank: React.PropTypes.array,
+    selectedStatus: React.PropTypes.array,
     handlePluginBtnOnAccordian: React.PropTypes.func
 };
 

--- a/includes/src/Report/Collapse.js
+++ b/includes/src/Report/Collapse.js
@@ -12,6 +12,7 @@ class Collapse extends React.Component {
         var selectedGroup = this.context.selectedGroup;
         var selectedOwtfRank = this.context.selectedOwtfRank;
         var selectedStatus = this.context.selectedStatus;
+        var pactive = this.props.pactive;
         return (
             <div id={plugin['code']} className="panel-collapse collapse">
                 <div className="panel-body">
@@ -23,7 +24,7 @@ class Collapse extends React.Component {
                             if ((selectedType.length === 0 || selectedType.indexOf(obj['plugin_type']) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(obj['plugin_group']) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(obj['user_rank']) !== -1) && (selectedOwtfRank.length === 0 || selectedOwtfRank.indexOf(obj['owtf_rank']) !== -1) && (selectedStatus.length === 0 || selectedStatus.indexOf(obj['status']) !== -1)) {
                                 var pkey = obj['plugin_type'] + '_' + obj['plugin_code'];
                                 return (
-                                    <li key={pkey} className={pluginData['pactive'] === obj['plugin_type']
+                                    <li key={pkey} className={pactive === obj['plugin_type']
                                         ? "active"
                                         : ""}>
                                         <a href={"#" + obj['plugin_group'] + '_' + obj['plugin_type'] + '_' + obj['plugin_code']} data-toggle="tab">
@@ -45,7 +46,7 @@ class Collapse extends React.Component {
                             if ((selectedType.length === 0 || selectedType.indexOf(obj['plugin_type']) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(obj['plugin_group']) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(obj['user_rank']) !== -1)) {
                                 var pkey = obj['plugin_type'] + '_' + obj['plugin_code'];
                                 return (
-                                    <div className={pluginData['pactive'] === obj['plugin_type']
+                                    <div className={pactive === obj['plugin_type']
                                         ? "tab-pane active"
                                         : "tab-pane"} id={obj['plugin_group'] + '_' + obj['plugin_type'] + '_' + obj['plugin_code']} key={"tab" + pkey}>
                                         <div className="pull-left" data-toggle="buttons-checkbox">

--- a/includes/src/Report/Collapse.js
+++ b/includes/src/Report/Collapse.js
@@ -7,6 +7,11 @@ class Collapse extends React.Component {
     render() {
         var plugin = this.props.plugin;
         var pluginData = this.props.pluginData;
+        var selectedType = this.context.selectedType;
+        var selectedRank = this.context.selectedRank;
+        var selectedGroup = this.context.selectedGroup;
+        var selectedOwtfRank = this.context.selectedOwtfRank;
+        var selectedStatus = this.context.selectedStatus;
         return (
             <div id={plugin['code']} className="panel-collapse collapse">
                 <div className="panel-body">
@@ -15,16 +20,18 @@ class Collapse extends React.Component {
                             <a className="btn" disabled="disabled">Type:</a>
                         </li>
                         {pluginData.map(function(obj) {
-                            var pkey = obj['plugin_type'] + '_' + obj['plugin_code'];
-                            return (
-                                <li key={pkey} className={pluginData['pactive'] === obj['plugin_type']
-                                    ? "active"
-                                    : ""}>
-                                    <a href={"#" + obj['plugin_group'] + '_' + obj['plugin_type'] + '_' + obj['plugin_code']} data-toggle="tab">
-                                        {obj['plugin_type'].split('_').join(' ')}
-                                    </a>
-                                </li>
-                            );
+                            if ((selectedType.length === 0 || selectedType.indexOf(obj['plugin_type']) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(obj['plugin_group']) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(obj['user_rank']) !== -1) && (selectedOwtfRank.length === 0 || selectedOwtfRank.indexOf(obj['owtf_rank']) !== -1) && (selectedStatus.length === 0 || selectedStatus.indexOf(obj['status']) !== -1)) {
+                                var pkey = obj['plugin_type'] + '_' + obj['plugin_code'];
+                                return (
+                                    <li key={pkey} className={pluginData['pactive'] === obj['plugin_type']
+                                        ? "active"
+                                        : ""}>
+                                        <a href={"#" + obj['plugin_group'] + '_' + obj['plugin_type'] + '_' + obj['plugin_code']} data-toggle="tab">
+                                            {obj['plugin_type'].split('_').join(' ')}
+                                        </a>
+                                    </li>
+                                );
+                            }
                         })}
                         <li className="pull-right">
                             <a href={plugin['url']} target="_blank" title="More information">
@@ -35,28 +42,30 @@ class Collapse extends React.Component {
                     <br/>
                     <div className="tab-content">
                         {pluginData.map(function(obj) {
-                            var pkey = obj['plugin_type'] + '_' + obj['plugin_code'];
-                            return (
-                                <div className={pluginData['pactive'] === obj['plugin_type']
-                                    ? "tab-pane active"
-                                    : "tab-pane"} id={obj['plugin_group'] + '_' + obj['plugin_type'] + '_' + obj['plugin_code']} key={"tab" + pkey}>
-                                    <div className="pull-left" data-toggle="buttons-checkbox">
-                                        <blockquote>
-                                            <h4>{obj['plugin_type'].split('_').join(' ').charAt(0).toUpperCase() + obj['plugin_type'].split('_').join(' ').slice(1)}</h4>
-                                            <small>{obj['plugin_code']}</small>
-                                        </blockquote>
-                                    </div>
-                                    <div data-toggle="buttons">
+                            if ((selectedType.length === 0 || selectedType.indexOf(obj['plugin_type']) !== -1) && (selectedGroup.length === 0 || selectedGroup.indexOf(obj['plugin_group']) !== -1) && (selectedRank.length === 0 || selectedRank.indexOf(obj['user_rank']) !== -1)) {
+                                var pkey = obj['plugin_type'] + '_' + obj['plugin_code'];
+                                return (
+                                    <div className={pluginData['pactive'] === obj['plugin_type']
+                                        ? "tab-pane active"
+                                        : "tab-pane"} id={obj['plugin_group'] + '_' + obj['plugin_type'] + '_' + obj['plugin_code']} key={"tab" + pkey}>
+                                        <div className="pull-left" data-toggle="buttons-checkbox">
+                                            <blockquote>
+                                                <h4>{obj['plugin_type'].split('_').join(' ').charAt(0).toUpperCase() + obj['plugin_type'].split('_').join(' ').slice(1)}</h4>
+                                                <small>{obj['plugin_code']}</small>
+                                            </blockquote>
+                                        </div>
+                                        <div data-toggle="buttons">
+                                            <br/>
+                                            <RankButtons obj={obj}/>
+                                        </div>
                                         <br/>
-                                        <RankButtons obj={obj}/>
+                                        <br/>
+                                        <br/>
+                                        <br/>
+                                        <Table obj={obj}/>
                                     </div>
-                                    <br/>
-                                    <br/>
-                                    <br/>
-                                    <br/>
-                                    <Table obj={obj}/>
-                                </div>
-                            );
+                                );
+                            }
                         })}
                     </div>
                 </div>
@@ -64,5 +73,13 @@ class Collapse extends React.Component {
         );
     }
 }
+
+Collapse.contextTypes = {
+    selectedType: React.PropTypes.array,
+    selectedRank: React.PropTypes.array,
+    selectedGroup: React.PropTypes.array,
+    selectedOwtfRank: React.PropTypes.array,
+    selectedStatus: React.PropTypes.array
+};
 
 export default Collapse;

--- a/includes/src/Report/SideFilters.js
+++ b/includes/src/Report/SideFilters.js
@@ -1,36 +1,47 @@
 import React from 'react';
 
-class SideFilters extends React.Component {
+class SideFilters extends React.PureComponent {
 
     render() {
         var updateFilter = this.context.updateFilter;
-        var selectedGroup = this.context.selectedGroup;
-        var selectedType = this.context.selectedType;
+        var selectedGroup = this.props.selectedGroup;
+        var selectedType = this.props.selectedType;
         var groups = ['web', 'network', 'auxiliary'];
-        var type = ['semi_passive', 'active', 'bruteforce', 'external', 'grep', 'passive'];
+        var type = [
+            'semi_passive',
+            'active',
+            'bruteforce',
+            'external',
+            'grep',
+            'passive'
+        ];
         return (
             <div id="plugin_nav">
                 {/* Plugin group and type filter */}
                 <strong>Plugin Group</strong><br/><br/>
                 <ul className="nav nav-pills nav-stacked">
-                  {groups.map(function(obj) {
-                      return (
-                        <li key={obj} role="presentation" className={selectedGroup.indexOf(obj) > -1 ? "active":""}>
-                            <a className="text-capitalize" href="#" onClick={updateFilter.bind(this, 'plugin_group', obj)}>{obj.replace("_", " ")}</a>
-                        </li>
-                      );
-                  })}
+                    {groups.map(function(obj) {
+                        return (
+                            <li key={obj} role="presentation" className={selectedGroup.indexOf(obj) > -1
+                                ? "active"
+                                : ""}>
+                                <a className="text-capitalize" href="#" onClick={updateFilter.bind(this, 'plugin_group', obj)}>{obj.replace("_", " ")}</a>
+                            </li>
+                        );
+                    })}
                 </ul>
                 <br/>
                 <strong>Plugin Types</strong><br/><br/>
                 <ul className="nav nav-pills nav-stacked">
-                  {type.map(function(obj) {
-                      return (
-                        <li key={obj} role="presentation" className={selectedType.indexOf(obj) > -1 ? "active" : ""}>
-                            <a className="text-capitalize" href="#" onClick={updateFilter.bind(this, 'plugin_type', obj)}>{obj.replace("_", " ")}</a>
-                        </li>
-                      );
-                  })}
+                    {type.map(function(obj) {
+                        return (
+                            <li key={obj} role="presentation" className={selectedType.indexOf(obj) > -1
+                                ? "active"
+                                : ""}>
+                                <a className="text-capitalize" href="#" onClick={updateFilter.bind(this, 'plugin_type', obj)}>{obj.replace("_", " ")}</a>
+                            </li>
+                        );
+                    })}
                 </ul>
             </div>
         );
@@ -38,8 +49,6 @@ class SideFilters extends React.Component {
 }
 
 SideFilters.contextTypes = {
-    selectedType: React.PropTypes.array,
-    selectedGroup: React.PropTypes.array,
     updateFilter: React.PropTypes.func
 };
 

--- a/includes/src/Report/Table.js
+++ b/includes/src/Report/Table.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {TARGET_API_URI} from '../constants';
 
-class Table extends React.Component {
+class Table extends React.PureComponent {
 
     patchUserNotes(group, type, code, user_notes) {
         var target_id = document.getElementById("report").getAttribute("data-code");

--- a/includes/src/Report/Toolbar.js
+++ b/includes/src/Report/Toolbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-class Toolbar extends React.Component {
+class Toolbar extends React.PureComponent {
 
     //Launch user sessions manager
     loadSessionManager() {
@@ -8,7 +8,7 @@ class Toolbar extends React.Component {
     };
 
     render() {
-        var selectedRank = this.context.selectedRank;
+        var selectedRank = this.props.selectedRank;
         var adv_filter_data = mySpace.adv_filter_data;
         var elem = document.createElement('textarea');
         elem.innerHTML = adv_filter_data;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "",
   "dependencies": {
     "chart.js": "^1.1.1",
+    "immutability-helper": "^2.0.0",
     "rc-progress": "^1.0.4",
     "react": "^15.2.1",
     "react-chartjs": "^0.7.3",


### PR DESCRIPTION
This PR fixes many issues in new UI of report.

## Description
Changes:
* Previously, we make requests to server for every plugin. suppose if there are 136 plugins in report. Corresponding requests will be 136. This was hogging server due to large number of simultaneous requests. This PR eliminate that and sends the requests in parts of 30. So that there can max be 5 requests in case of 136. This eliminate hogging issue and also fasts the UI as we are doing the requests in parts.
* Previously, we make updated request(for data) for filtering to server anytime any filtering is requested. This PR eliminate server side filtering to client side filtering as we have all the data on load. So it is redundant to send the requests again. Now we just request the updated names of plugins after filtering which is very small request in term of response.

Above point makes UI superfast. As there is not server level delay after page load. Everything is dependent of client side after first load.

## Related Issue
#771 

## Reviewers
@delta24


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

