### PR TITLE
Fixes #766. Owtf now refuses to run in its own directory

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -116,7 +116,7 @@ def finish(error_code):
             Colorizer.normal("[*] Visit https://github.com/owtf/owtf for help ")
         else:
             Colorizer.success("[*] Finished!")
-            Colorizer.info("[*] Start OWTF by running './owtf.py' in parent directory")
+            Colorizer.info("[*] Start OWTF by running 'cd /path/to/pentest/directory' \n'/path/to/owtf.py'")
 
 
 def install(cmd_arguments):

--- a/owtf.py
+++ b/owtf.py
@@ -255,4 +255,9 @@ def main(args):
 
 
 if __name__ == "__main__":
+
+    if 'owtf.py' in os.listdir(os.getcwd()) or 'owtf' == os.getcwd()[:-4:]:
+        usage("Start owtf in a different directory. 'cd /path/to/pentest/directory' \n'/path/to/owtf.py'")
+        exit(-1)
+
     main(sys.argv)


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Whenever owtf is run from its own directory it exits giving an error message.
Also the message after installation is not misleading anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#766 #746
