### PR TITLE
Added a name field to the data sent about the workers, Fixes #758

### DIFF
--- a/framework/plugin/worker_manager.py
+++ b/framework/plugin/worker_manager.py
@@ -211,6 +211,7 @@ class WorkerManager(BaseComponent, WorkerManagerInterface):
         if pseudo_index:
             try:
                 temp_dict = dict(self.workers[pseudo_index - 1])
+                temp_dict["name"] = temp_dict["worker"].name
                 temp_dict["worker"] = temp_dict["worker"].pid
                 temp_dict["id"] = pseudo_index
                 return temp_dict
@@ -220,6 +221,7 @@ class WorkerManager(BaseComponent, WorkerManagerInterface):
             worker_temp_list = []
             for i, obj in enumerate(self.workers):
                 temp_dict = dict(self.workers[i])
+                temp_dict["name"] = temp_dict["worker"].name
                 temp_dict["worker"] = temp_dict["worker"].pid
                 temp_dict["id"] = i + 1  # Zero-Index is not human friendly
                 worker_temp_list.append(temp_dict)


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
Added the worker name in the dictionary used to send workers data.

## Description
<!--- Describe your changes in detail -->
The worker's log are written to the file named same as workers. The workers name is not sent in case of API call. This will add worker's name to the data sent.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#758 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now the correct worker logs can be obtained using this data.

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@delta24 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

