### PR TITLE
[Dashboard] Adds multi session support to Dashboard

### DIFF
--- a/framework/db/poutput_manager.py
+++ b/framework/db/poutput_manager.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from framework.dependency_management.dependency_resolver import BaseComponent
 from framework.dependency_management.interfaces import PluginOutputInterface
 from framework.db.target_manager import target_required
+from framework.db.session_manager import session_required
 from framework.lib.exceptions import InvalidParameterType
 from framework.db import models
 from framework.utils import FileOperations
@@ -250,7 +251,8 @@ class POutputDB(BaseComponent, PluginOutputInterface):
             self.db.session.rollback()
             raise e
 
-    def GetSeverityFrequency(self):
+    @session_required
+    def GetSeverityFrequency(self, session_id=None):
         severity_frequency = [
             {"id": 0, "label": "Passing", "value": 0},
             {"id": 1, "label": "Info", "value": 0},
@@ -259,14 +261,21 @@ class POutputDB(BaseComponent, PluginOutputInterface):
             {"id": 4, "label": "High", "value": 0},
             {"id": 5, "label": "Critical", "value": 0},
         ]
+
+        targets = []
+        target_objs = self.db.session.query(models.Target.id).filter(models.Target.sessions.any(id=session_id)).all()
+        for target_obj in target_objs:
+            targets.append(target_obj.id)
+
         plugin_objs = self.db.session.query(models.PluginOutput).all()
 
         for plugin_obj in plugin_objs:
-            if plugin_obj.user_rank != -1:
-                severity_frequency[plugin_obj.user_rank]["value"] += 1
-            else:
-                if plugin_obj.owtf_rank != -1:
-                    # Removing the not ranked plugins
-                    severity_frequency[plugin_obj.owtf_rank]["value"] += 1
+            if plugin_obj.target_id in targets:
+                if plugin_obj.user_rank != -1:
+                    severity_frequency[plugin_obj.user_rank]["value"] += 1
+                else:
+                    if plugin_obj.owtf_rank != -1:
+                        # Removing the not ranked plugins
+                        severity_frequency[plugin_obj.owtf_rank]["value"] += 1
 
         return {"data": severity_frequency[::-1]}

--- a/framework/db/target_manager.py
+++ b/framework/db/target_manager.py
@@ -331,7 +331,8 @@ class TargetDB(BaseComponent, TargetInterface):
             results.append(values)
         return ({"data": results})
 
-    def GetTargetsSeverityCount(self):
+    @session_required
+    def GetTargetsSeverityCount(self, session_id=None):
         filtered_severity_objs = []
         # "not ranked" = gray, "passing" = light green, "info" = light sky blue, "low" = blue, medium = yellow, high = red, critical = dark purple
         severity_frequency = [
@@ -343,8 +344,8 @@ class TargetDB(BaseComponent, TargetInterface):
             {"id":5, "label": "High", "value": 0, "color": "#c12e2a"},
             {"id":6, "label": "Critical", "value": 0, "color": "#800080"}
         ]
-        total = self.db.session.query(models.Target).count()
-        target_objs = self.db.session.query(models.Target).all()
+        total = self.db.session.query(models.Target).filter(models.Target.sessions.any(id=session_id)).count()
+        target_objs = self.db.session.query(models.Target).filter(models.Target.sessions.any(id=session_id)).all()
 
         for target_obj in target_objs:
             if target_obj.max_user_rank != -1:


### PR DESCRIPTION
Previously, Dashboard shows all items (not specific to active session)
This PR fixes this issue and will show results specific to active session.

## Description
Code wise change(For chart): Adds filter in DB queries for session.
For Panel: Get targets specific to session and filter plugin_outputs by targets too.

## Reviewers
@delta24 @7a 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other
