### PR TITLE
Bug in ranking a plugin

### DIFF
--- a/framework/db/poutput_manager.py
+++ b/framework/db/poutput_manager.py
@@ -172,6 +172,7 @@ class POutputDB(BaseComponent, PluginOutputInterface):
                     if isinstance(patch_data["user_rank"], list):
                         patch_data["user_rank"] = patch_data["user_rank"][0]
                     obj.user_rank = int(patch_data["user_rank"])
+                    obj.owtf_rank = -1
                 if patch_data.get("user_notes", None):
                     if isinstance(patch_data["user_notes"], list):
                         patch_data["user_notes"] = patch_data["user_notes"][0]


### PR DESCRIPTION
## Description
Previously, if user ranks a plugins an api call only updates **user_rank** to corresponding rank.
Ideally we should also update owtf_rank because for suppose before rank PATCH call owtf ranks plugin to for say "info" but if we update the plugin user_rank to "passing" (because sometimes automated tools flag many things as findings which are really stupid) max_owtf_rank will still remain higher than max_user_rank for that target which is a bug actually. 
For example:
if only partially ranked, let's say, 3 automated plugins have an automated ranking and the human ONLY overwrote ONE, then **you still have to use the max of (automated, human) until the human overwrites the other automatically ranked plugins**.

Point is **if user_rank exist for some plugin then there is no requirement of owtf_rank.**

The point of **owtf_rank** is to attract the attention of the penetration tester towards the seemingly weaker hosts.

## Reviewers
@delta24 @7a 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other
