### PR TITLE
Adds support to show all targets

### DIFF
--- a/framework/db/target_manager.py
+++ b/framework/db/target_manager.py
@@ -246,7 +246,8 @@ class TargetDB(BaseComponent, TargetInterface):
                 if filter_data.get('limit', None):
                     if isinstance(filter_data.get('limit'), list):
                         filter_data['limit'] = filter_data['limit'][0]
-                    query = query.limit(int(filter_data['limit']))
+                    if int(filter_data['limit']) != -1:
+                        query = query.limit(int(filter_data['limit']))
             except ValueError:
                 raise InvalidParameterType("Invalid parameter type for target db for id[lt] or id[gt]")
         return query

--- a/framework/interface/templates/target_manager.html
+++ b/framework/interface/templates/target_manager.html
@@ -541,6 +541,7 @@ function drawTargetTable() {
         "stateSave": true,
         "bServerSide": true,
         "ajax": dummyAjax,
+        "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
         "fnDrawCallback": function( settings ) {
             // Managing the "Select all" checkbox
             // everytime the table is drawn, it checks if all the


### PR DESCRIPTION
 ## Description
Previously, only 4 options were available 10,25,50,100. This fix will add another option to show all at once. 
Major concern of this fix is issue #821 . Logically, select all of target data-table is working correctly IMO it should only select visible entries. To fix #821 I think this should be a proper fix.
Advantage of this fix is suppose you want to carry out operation on particular set of 10 targets for say 20-30 targets you can go to pagination 2 and click select all. In this way this functionality gives you more options  and wider range of selection as compared to if you select **all** using **select all checkbox**.

## Reviewers
@delta24 @7a 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other
