### PR TITLE
Fixed issue in path of plugin groups

### DIFF
--- a/configuration/framework_config.cfg
+++ b/configuration/framework_config.cfg
@@ -6,6 +6,11 @@
 
 #------------------------- Settings Directory ----------------------->
 SETTINGS_DIR: ~/.owtf
+CONFIG_DIR: @@@FRAMEWORK_DIR@@@/configuration/
+# These config directory are relative to CONFIG_DIR
+WEB_PLUGIN_CONFIG_DIR: profiles/plugin_web/
+AUX_PLUGIN_CONFIG_DIR: profiles/plugin_aux/
+NET_PLUGIN_CONFIG_DIR: profiles/plugin_net/
 
 # ----------------------- Version Information ----------------------- #
 VERSION: 2.0a
@@ -29,9 +34,9 @@ ZAP_PROXY_PORT: 8090
 
 # -------------------------- Main file paths -------------------------- #
 INSTALL_SCRIPT: @@@FRAMEWORK_DIR@@@/install/install.py
-WEB_TEST_GROUPS: .owtf/configuration/profiles/plugin_web/groups.cfg
-NET_TEST_GROUPS: .owtf/configuration/profiles/plugin_net/groups.cfg
-AUX_TEST_GROUPS: .owtf/configuration/profiles/plugin_aux/groups.cfg
+WEB_TEST_GROUPS: ~/.owtf/configuration/profiles/plugin_web/groups.cfg
+NET_TEST_GROUPS: ~/.owtf/configuration/profiles/plugin_net/groups.cfg
+AUX_TEST_GROUPS: ~/.owtf/configuration/profiles/plugin_aux/groups.cfg
 PLUGINS_DIR: @@@FRAMEWORK_DIR@@@/plugins/
 
 
@@ -45,11 +50,11 @@ TARGETS_DIR: targets
 
 
 # ---------------------- Default profile settings ---------------------- #
-DEFAULT_GENERAL_PROFILE: .owtf/configuration/general.cfg
-DEFAULT_RESOURCES_PROFILE: .owtf/configuration/resources.cfg
-DEFAULT_MAPPING_PROFILE: .owtf/configuration/mappings.cfg
-DEFAULT_WEB_PLUGIN_ORDER_PROFILE: .owtf/configuration/profiles/plugin_web/order.cfg
-DEFAULT_NET_PLUGIN_ORDER_PROFILE: .owtf/configuration/profiles/plugin_net/order.cfg
+DEFAULT_GENERAL_PROFILE: ~/.owtf/configuration/general.cfg
+DEFAULT_RESOURCES_PROFILE: ~/.owtf/configuration/resources.cfg
+DEFAULT_MAPPING_PROFILE: ~/.owtf/configuration/mappings.cfg
+DEFAULT_WEB_PLUGIN_ORDER_PROFILE: ~/.owtf/configuration/profiles/plugin_web/order.cfg
+DEFAULT_NET_PLUGIN_ORDER_PROFILE: ~/.owtf/configuration/profiles/plugin_net/order.cfg
 
 
 # ---------------------------- URL regexps ---------------------------- #

--- a/framework/config/config.py
+++ b/framework/config/config.py
@@ -32,6 +32,7 @@ class Config(BaseComponent, ConfigInterface):
 
     RootDir = None
     OwtfPid = None
+    Framework_config_path = os.path.expanduser(os.path.join("~", '.owtf', 'configuration', 'framework_config.cfg'))
     Profiles = {
         "GENERAL_PROFILE": None,
         "RESOURCES_PROFILE": None,
@@ -57,8 +58,7 @@ class Config(BaseComponent, ConfigInterface):
         # Available profiles = g -> General configuration, n -> Network plugin
         # order, w -> Web plugin order, r -> Resources file
         self.initialize_attributes()
-        self.LoadFrameworkConfigFromFile(self.select_user_or_default_config_path(
-            os.path.join('.owtf', 'configuration', 'framework_config.cfg')))
+        self.LoadFrameworkConfigFromFile(self.framework_config_file_path())
 
     def init(self):
         """Initialize the Option resources."""
@@ -80,11 +80,18 @@ class Config(BaseComponent, ConfigInterface):
         :param default_path: Default path of this file relative to "@@@RootDir@@@/configuration/" excluding filename
         :return: Absolute path of the file if found else default path
         """
-        file_path = os.path.join(os.path.expanduser('~'), file_path)
+        file_path = os.path.expanduser(file_path)
         if os.path.isfile(file_path):
             return file_path
 
-        path = os.path.join(self.RootDir, 'configuration', default_path, os.path.basename(file_path))
+        path = os.path.join(self.FrameworkConfigGet("CONFIG_DIR"), default_path, os.path.basename(file_path))
+        return path
+
+    def framework_config_file_path(self):
+        if os.path.isfile(self.Framework_config_path):
+            return self.Framework_config_path
+
+        path = os.path.join(self.RootDir, 'configuration', os.path.basename(self.Framework_config_path))
         return path
 
     def LoadFrameworkConfigFromFile(self, config_path):

--- a/framework/config/config.py
+++ b/framework/config/config.py
@@ -73,13 +73,18 @@ class Config(BaseComponent, ConfigInterface):
         for type in CONFIG_TYPES:
             self.Config[type] = {}
 
-    def select_user_or_default_config_path(self, file_path):
-        """If user config files are present return the passed file path, else the default config file path."""
+    def select_user_or_default_config_path(self, file_path, default_path=""):
+        """
+        If user config files are present return the passed file path, else the default config file path
+        :param file_path: Path of config file to locate
+        :param default_path: Default path of this file relative to "@@@RootDir@@@/configuration/" excluding filename
+        :return: Absolute path of the file if found else default path
+        """
         file_path = os.path.join(os.path.expanduser('~'), file_path)
         if os.path.isfile(file_path):
             return file_path
 
-        path = os.path.join(self.RootDir, 'configuration', os.path.basename(file_path))
+        path = os.path.join(self.RootDir, 'configuration', default_path, os.path.basename(file_path))
         return path
 
     def LoadFrameworkConfigFromFile(self, config_path):

--- a/framework/db/plugin_manager.py
+++ b/framework/db/plugin_manager.py
@@ -23,11 +23,11 @@ class PluginDB(BaseComponent, DBPluginInterface):
         self.db = self.get_component("db")
         self.error_handler = self.get_component("error_handler")
         self.LoadTestGroups(self.config.select_user_or_default_config_path(
-            self.config.FrameworkConfigGet("WEB_TEST_GROUPS")), "web")
+            self.config.FrameworkConfigGet("WEB_TEST_GROUPS"), os.path.join("profiles","plugin_web")), "web")
         self.LoadTestGroups(self.config.select_user_or_default_config_path(
-            self.config.FrameworkConfigGet("NET_TEST_GROUPS")), "network")
+            self.config.FrameworkConfigGet("NET_TEST_GROUPS"), os.path.join("profiles","plugin_net")), "network")
         self.LoadTestGroups(self.config.select_user_or_default_config_path(
-            self.config.FrameworkConfigGet("AUX_TEST_GROUPS")), "auxiliary")
+            self.config.FrameworkConfigGet("AUX_TEST_GROUPS"), os.path.join("profiles","plugin_aux")), "auxiliary")
         # After loading the test groups then load the plugins, because of many-to-one relationship
         self.LoadFromFileSystem()  # Load plugins :P
 

--- a/framework/db/plugin_manager.py
+++ b/framework/db/plugin_manager.py
@@ -23,11 +23,14 @@ class PluginDB(BaseComponent, DBPluginInterface):
         self.db = self.get_component("db")
         self.error_handler = self.get_component("error_handler")
         self.LoadTestGroups(self.config.select_user_or_default_config_path(
-            self.config.FrameworkConfigGet("WEB_TEST_GROUPS"), os.path.join("profiles","plugin_web")), "web")
+            self.config.FrameworkConfigGet("WEB_TEST_GROUPS"), self.config.FrameworkConfigGet("WEB_PLUGIN_CONFIG_DIR")),
+            "web")
         self.LoadTestGroups(self.config.select_user_or_default_config_path(
-            self.config.FrameworkConfigGet("NET_TEST_GROUPS"), os.path.join("profiles","plugin_net")), "network")
+            self.config.FrameworkConfigGet("NET_TEST_GROUPS"), self.config.FrameworkConfigGet("NET_PLUGIN_CONFIG_DIR")),
+            "network")
         self.LoadTestGroups(self.config.select_user_or_default_config_path(
-            self.config.FrameworkConfigGet("AUX_TEST_GROUPS"), os.path.join("profiles","plugin_aux")), "auxiliary")
+            self.config.FrameworkConfigGet("AUX_TEST_GROUPS"), self.config.FrameworkConfigGet("AUX_PLUGIN_CONFIG_DIR")),
+            "auxiliary")
         # After loading the test groups then load the plugins, because of many-to-one relationship
         self.LoadFromFileSystem()  # Load plugins :P
 


### PR DESCRIPTION
This bug was introduced in [this](https://github.com/owtf/owtf/commit/6c1ff855773914919f9c3dc3d213bdf0dce16ab4) commit.

### Current Behaviour:
If any configuration file is missing in `~/.owtf/` folder then current owtf expects it to be strictly in `@@@RootDir@@@/configuration/`. As the default plugin config files are in `@@@RootDir@@@/configuration/profiles/`, this makes default files unavailable.

### Expected Behaviour:
The path of the config files should be stored in the framework config file and the function returning the path of config file must not have path hard coded.

This PR fixes the error in default path extraction. When default path is calculated it expects default file path relative to @@@RootDir@@@/configuration.