### PR TITLE
Added upgrade option to all pip commands, Fixes #833

### DIFF
--- a/install/arch/PKGBUILD
+++ b/install/arch/PKGBUILD
@@ -33,7 +33,7 @@ pkgver() {
 
 package() {
 
-    pip2 install PTP python-owasp-zap-v2 PyVirtualDisplay selenium
+    pip2 install --upgrade PTP python-owasp-zap-v2 PyVirtualDisplay selenium
 
     cd "$srcdir/owtf"
 

--- a/install/install.py
+++ b/install/install.py
@@ -147,11 +147,11 @@ def setup_pip():
         ' Firefox/15.0" --tries=3 https://bootstrap.pypa.io/get-pip.py; sudo python get-pip.py;}'
     install_in_directory(os.path.expanduser(directory), command)
     Colorizer.info("[*] Installing required packages for pipsecure")
-    run_command("sudo pip2 install pyopenssl ndg-httpsclient pyasn1")
+    run_command("sudo pip2 install --upgrade pyopenssl ndg-httpsclient pyasn1")
 
     # Installing virtualenv
     Colorizer.info("[*] Installing virtualenv and virtualenvwrapper")
-    install_in_directory(os.path.expanduser(str(os.getpid())), "sudo pip2 install virtualenv virtualenvwrapper")
+    install_in_directory(os.path.expanduser(str(os.getpid())), "sudo pip2 install --upgrade virtualenv virtualenvwrapper")
 
 
 def install(cmd_arguments):

--- a/install/kali/install.sh
+++ b/install/kali/install.sh
@@ -19,7 +19,7 @@ RootDir=$1
 apt_wrapper_path="$RootDir/install/aptitude-wrapper.sh"
 # Perform apt-get update before starting to install all packages, so we can get the latests manifests and packages versions
 sudo apt-get update
-sudo -E "$apt_wrapper_path" python-pip xvfb xserver-xephyr libxml2-dev libxslt-dev libssl-dev zlib1g-dev gcc python-dev
+sudo -E "$apt_wrapper_path" xvfb xserver-xephyr libxml2-dev libxslt-dev libssl-dev zlib1g-dev gcc python-dev
 export PYCURL_SSL_LIBRARY=gnutls # Needed for installation of pycurl using pip in kali
 
 # psycopg2 dependency

--- a/install/kali/kali_patch_w3af.sh
+++ b/install/kali/kali_patch_w3af.sh
@@ -5,9 +5,9 @@
 
 # Install missing stuff needed for w3af in kali
 sudo apt-get -y install python2.7-dev libsqlite3-dev
-pip2 install clamd PyGithub GitPython pybloomfiltermmap esmre nltk pdfminer futures guess-language cluster msgpack-python python-ntlm
-pip2 install git+https://github.com/ramen/phply.git\#egg=phply
-pip2 install xdot
+pip2 install --upgrade clamd PyGithub GitPython pybloomfiltermmap esmre nltk pdfminer futures guess-language cluster msgpack-python python-ntlm
+pip2 install --upgrade git+https://github.com/ramen/phply.git\#egg=phply
+pip2 install --upgrade xdot
 
 if [ ! -f ~/.w3af/startup.conf ]
 then

--- a/install/samurai/samurai_wtf_patch_w3af.sh
+++ b/install/samurai/samurai_wtf_patch_w3af.sh
@@ -5,9 +5,9 @@
 
 # Install missing stuff needed for w3af in kali
 sudo apt-get -y install python2.7-dev libsqlite3-dev
-pip2 install clamd PyGithub GitPython pybloomfiltermmap esmre nltk pdfminer futures guess-language cluster msgpack-python python-ntlm
-pip2 install git+https://github.com/ramen/phply.git\#egg=phply
-pip2 install xdot
+pip2 install --upgrade clamd PyGithub GitPython pybloomfiltermmap esmre nltk pdfminer futures guess-language cluster msgpack-python python-ntlm
+pip2 install --upgrade git+https://github.com/ramen/phply.git\#egg=phply
+pip2 install --upgrade xdot
 
 if [ ! -f ~/.w3af/startup.conf ]
 then


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
Some pip commands are not having --upgrade option, resulting in leaving dependencies in older version. This has created issues while installing OWTF (currently due to pyopenssl).

## Description
<!--- Describe your changes in detail -->
Added --upgrade option to all pip commands

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#833

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It will solve problem in installation of OWTF.

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@viyatb 

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
