### PR TITLE
[virtualenv] Select python 2.7 as the default version for venv

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -114,11 +114,15 @@ def finish():
 
 
 def setup_virtualenv():
-    Colorizer.info("[*] Seting up virtual environment named owtf...")
+    Colorizer.info("[*] Setting up virtual environment named owtf...")
+    # If /usr/local/bin/virtualenvwrapper.sh doesn't exist, create a symlink from /usr/bin/
+    if not os.path.isfile('/usr/local/bin/virtualenvwrapper.sh'):
+        run_command('sudo ln -s /usr/bin/virtualenvwrapper.sh /usr/local/bin/virtualenvwrapper.sh >/dev/null 2>&1;')
+
     # sources files and commands
     source = 'source /usr/local/bin/virtualenvwrapper.sh'
-    setup_env = 'cd $WORKON_HOME; virtualenv -q --always-copy -p %s owtf >/dev/null 2>&1;'\
-        ' source owtf/bin/activate' % sys.executable
+    setup_env = 'cd $WORKON_HOME; virtualenv -q --always-copy --python=python2.7 owtf >/dev/null 2>&1;'\
+        ' source owtf/bin/activate'
     dump = '%s -c "import os, json;print json.dumps(dict(os.environ))"' % sys.executable
 
     pipe = subprocess.Popen(['/bin/bash', '-c', '%s >/dev/null 2>&1; %s; %s' % (source, setup_env, dump)],


### PR DESCRIPTION
Changes the virtualenv setup command to default to `python2.7` as the default version.