### PR TITLE
[install] Move pre-launch checks to framework __init__.py file

### DIFF
--- a/framework/__init__.py
+++ b/framework/__init__.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+from framework.dependency_check import verify_dependencies
+
+
+"""
+Checks if the script is running inside a virtualenv or not
+Stolen from http://stackoverflow.com/questions/1871549/python-determine-if-running-inside-virtualenv
+Inside a virtualenv, sys.prefix points to the virtualenv directory,
+and sys.real_prefix points to the "real" prefix of the system Python (often /usr or /usr/local or some such).
+
+Outside the virtualenv, sys.real_prefix does not exist.
+"""
+if not hasattr(sys, 'real_prefix'):
+    print("[-] It seems that virtualenv has not been activated!\n")
+    print("[-] Please run: \t source ~/.%src; workon owtf\n" % os.environ["SHELL"].split(os.sep)[-1])
+    sys.exit(1)
+
+verify_dependencies(os.path.dirname(os.path.abspath(sys.argv[0])) or '.')

--- a/framework/utils.py
+++ b/framework/utils.py
@@ -96,20 +96,6 @@ def print_version(root_dir, commit_hash=False, version=False):
         pass
 
 
-def check_if_virtualenv_python():
-    """Checks if the script is running inside a virtualenv or not
-    Stolen from http://stackoverflow.com/questions/1871549/python-determine-if-running-inside-virtualenv
-    - Inside a virtualenv, sys.prefix points to the virtualenv directory,
-    and sys.real_prefix points to the "real" prefix of the system Python (often /usr or /usr/local or some such).
-
-    Outside the virtualenv, sys.real_prefix does not exist.
-    """
-    if not hasattr(sys, 'real_prefix'):
-        print("[-] It seems that virtualenv has not been activated!\n")
-        print("[-] Please run: \t source ~/.%src; workon owtf\n" % os.environ["SHELL"].split(os.sep)[-1])
-        sys.exit(1)
-
-
 class FileOperations(object):
 
     @staticmethod

--- a/owtf.py
+++ b/owtf.py
@@ -10,16 +10,11 @@ import os
 import sys
 import logging
 
-from framework.dependency_check import verify_dependencies
 from framework.core import Core
 from framework.dependency_management.component_initialiser import ComponentInitialiser, DatabaseNotRunningException
 from framework.dependency_management.dependency_resolver import ServiceLocator
 from framework import update
-from framework.utils import check_if_virtualenv_python
 from framework.lib.cli_options import usage, parse_options, parse_update_options
-
-check_if_virtualenv_python()
-verify_dependencies(os.path.dirname(os.path.abspath(sys.argv[0])) or '.')
 
 
 def banner():


### PR DESCRIPTION
This PR forces OWTF to check if the Python virtualenv is activated before importing any OWTF modules in the main script.