### PR TITLE
Adds environment and adds instructions for docker installation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM kalilinux/kali-linux-docker
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get -y update && apt-get -y dist-upgrade && apt-get clean
 
-RUN apt-get -y update && apt-get -y upgrade
 # Install certificates to ensure https links in wget work
 RUN apt-get -y install ca-certificates
 # Install sudo, python, and Java for Zest functionality

--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ or simply `git clone https://github.com/owtf/owtf.git; cd owtf/; python2 install
 
 To run OWTF on Windows or MacOS, use the Dockerfile (requires **Docker** installed) provided to try OWTF:
 
-`docker build -t owtf-dev .`
-
-`docker run -it -p 8009:8009 -p 8008:8008 -p 8010:8010 -v ~/path_to_OWTF_on_host:/owtf owtf-dev /bin/bash`
+ - `$ docker build -t owtf-dev .`
+ - `$ docker run -it -p 8009:8009 -p 8008:8008 -p 8010:8010 -v ~/path_to_OWTF_on_host:/owtf owtf-dev /bin/bash`
+ - Open `~/.owtf/configuration` and change `SERVER_ADDR: 127.0.0.1` to `SERVER_ADDR: 0.0.0.0`.
+ - Run owtf
+ - Open `localhost:8009` for OWTF webUI.
 
 License
 ===


### PR DESCRIPTION
Fixes environment and interface issues with Docker Installations.

## Description
Previously, Interface was `127.0.0.1` due to which after binding the ports, tester couldn't access OWTF webUI.
This PR adds instructions to fix it.

## Reviewers
@viyatb @7a 

## How Has This Been Tested?
Tested on docker container on mac OSX.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
