### PR TITLE
Update run_nikto.sh -- ssl and nossl fix.

### DIFF
--- a/scripts/run_nikto.sh
+++ b/scripts/run_nikto.sh
@@ -31,9 +31,17 @@ if [ "$5" ] && [ "$5" != "$ip" ]; then
 fi
 
 NIKTO_SSL=""
-SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -connect "$HOST_NAME":"$PORT" -brief 2>&1 | grep "ESTABLISHED" | wc -l)
-if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then # SSL connection successful, proceed with nikto -ssl switch
-        NIKTO_SSL="-ssl"
+SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -connect "$HOST_NAME":"$PORT" -brief 2>&1 | grep "ESTABLISHED" | wc -l )
+
+if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then # SSL connection successful, procede with -ssl switch
+       NIKTO_SSL="-ssl"
+       echo  "ssl-connection"
+echo
+fi
+if [ "$SSL_CONNECTION_LINES" -lt 1 ]; then # nossl connection.
+         NIKTO_SSL="-nossl"
+         echo "No-ssl_Connection"
+echo
 fi
 
 # Temporary nikto config file

--- a/scripts/run_nikto.sh
+++ b/scripts/run_nikto.sh
@@ -30,14 +30,11 @@ if [ "$5" ] && [ "$5" != "$ip" ]; then
         NIKTO_NOLOOKUP="" #Host name passed: must look up
 fi
 
-NIKTO_SSL=""
+NIKTO_SSL="-nossl"
 SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -connect "$HOST_NAME":"$PORT" -brief 2>&1 | grep "ESTABLISHED" | wc -l )
 
 if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then # SSL connection successful, proceed with -ssl switch
        NIKTO_SSL="-ssl"
-fi
-if [ "$SSL_CONNECTION_LINES" -lt 1 ]; then # nossl connection.
-         NIKTO_SSL="-nossl"
 fi
 
 # Temporary nikto config file

--- a/scripts/run_nikto.sh
+++ b/scripts/run_nikto.sh
@@ -33,7 +33,7 @@ fi
 NIKTO_SSL=""
 SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -connect "$HOST_NAME":"$PORT" -brief 2>&1 | grep "ESTABLISHED" | wc -l )
 
-if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then # SSL connection successful, procede with -ssl switch
+if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then # SSL connection successful, proceed with -ssl switch
        NIKTO_SSL="-ssl"
 fi
 if [ "$SSL_CONNECTION_LINES" -lt 1 ]; then # nossl connection.

--- a/scripts/run_nikto.sh
+++ b/scripts/run_nikto.sh
@@ -71,5 +71,12 @@ COMMAND="nikto $NIKTO_NOLOOKUP -evasion 1 $NIKTO_SSL -config $TEMP_NIKTO_CONF_FI
 echo "[*] Running: $COMMAND"
 $COMMAND
 
+SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -connect "$HOST_NAME":"$PORT" -brief 2>&1 | grep "ESTABLISHED" | wc -l )
+if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then
+echo      "ssl-Connection"
+fi
+if [ "$SSL_CONNECTION_LINES" -lt 1 ]; then 
+echo      "No-ssl-Connection"
+fi
 echo
 echo "[*] Done!"

--- a/scripts/run_nikto.sh
+++ b/scripts/run_nikto.sh
@@ -35,13 +35,9 @@ SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -c
 
 if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then # SSL connection successful, procede with -ssl switch
        NIKTO_SSL="-ssl"
-       echo  "ssl-connection"
-echo
 fi
 if [ "$SSL_CONNECTION_LINES" -lt 1 ]; then # nossl connection.
          NIKTO_SSL="-nossl"
-         echo "No-ssl_Connection"
-echo
 fi
 
 # Temporary nikto config file
@@ -71,12 +67,6 @@ COMMAND="nikto $NIKTO_NOLOOKUP -evasion 1 $NIKTO_SSL -config $TEMP_NIKTO_CONF_FI
 echo "[*] Running: $COMMAND"
 $COMMAND
 
-SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -connect "$HOST_NAME":"$PORT" -brief 2>&1 | grep "ESTABLISHED" | wc -l )
-if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then
-echo      "ssl-Connection"
-fi
-if [ "$SSL_CONNECTION_LINES" -lt 1 ]; then 
-echo      "No-ssl-Connection"
-fi
+
 echo
 echo "[*] Done!"


### PR DESCRIPTION
## Description
Changes in /owtf/scripts/run_nikto.sh 
changed -gt 0 | -lt 1 | i.e SSL and NON-SSL Connections 

## Reviewer
@7a 

## Tested:
[- nossl]
root@kali:~#cd owtf_review/target/http__target.com8080_/partial/Nikto_Unauthenticated/active;sh /root/owtf/scripts/run_nikto.sh /usr/share/nikto 23.205.118.83 127.0.0.1:8080 8080 target.com


[ssl]
root@kali:~# cd owtf_review/target/http__target.com80_/partial/Nikto_Unauthenticated/active;sh /root/owtf/scripts/run_nikto.sh /usr/share/nikto 23.205.118.74 127.0.0.1:8080 80 target.com

## ScreenShot


![nikto](https://user-images.githubusercontent.com/10548085/28661949-76c26728-7286-11e7-934a-415ccde508a2.png)
still there are some things might need to change in .config file.

## Code 
NIKTO_SSL=""
SSL_CONNECTION_LINES=$(sleep 5 ; echo -e "^C" 2> /dev/null | openssl s_client -connect "$HOST_NAME":"$PORT" -brief 2>&1 | grep "ESTABLISHED" | wc -l )

if [ "$SSL_CONNECTION_LINES" -gt 0 ]; then 
       NIKTO_SSL="-ssl"
       echo  "ssl-connection"
echo
fi
if [ "$SSL_CONNECTION_LINES" -lt 1 ]; then
         NIKTO_SSL="-nossl"
         echo "No-ssl_Connection"
echo
fi

