### PR TITLE
Fix issue when target url contains reserved characters

### DIFF
--- a/framework/interface/reporter.py
+++ b/framework/interface/reporter.py
@@ -7,6 +7,7 @@ The reporter module is in charge of producing the HTML Report as well as
 import cgi
 
 from tornado.template import Loader
+from tornado.escape import url_escape
 
 from framework.dependency_management.dependency_resolver import BaseComponent
 from framework.dependency_management.interfaces import ReporterInterface
@@ -136,7 +137,7 @@ class Reporter(BaseComponent, ReporterInterface):
             "Name": Name,
             "CommandIntro": CommandIntro,
             "ModifiedCommand": ModifiedCommand,
-            "FilePath": RelativeFilePath,
+            "FilePath": url_escape(RelativeFilePath),
             "OutputIntro": OutputIntro,
             "OutputLines": OutputLines,
             "TimeStr": TimeStr,

--- a/framework/interface/reporter.py
+++ b/framework/interface/reporter.py
@@ -7,7 +7,6 @@ The reporter module is in charge of producing the HTML Report as well as
 import cgi
 
 from tornado.template import Loader
-from tornado.escape import url_escape
 
 from framework.dependency_management.dependency_resolver import BaseComponent
 from framework.dependency_management.interfaces import ReporterInterface

--- a/framework/interface/reporter.py
+++ b/framework/interface/reporter.py
@@ -137,7 +137,7 @@ class Reporter(BaseComponent, ReporterInterface):
             "Name": Name,
             "CommandIntro": CommandIntro,
             "ModifiedCommand": ModifiedCommand,
-            "FilePath": url_escape(RelativeFilePath),
+            "FilePath": RelativeFilePath,
             "OutputIntro": OutputIntro,
             "OutputLines": OutputLines,
             "TimeStr": TimeStr,

--- a/includes/src/Report/Table.jsx
+++ b/includes/src/Report/Table.jsx
@@ -56,7 +56,7 @@ class Table extends React.PureComponent {
 
     render() {
         var obj = this.props.obj;
-        var output_path = obj['output_path'];
+        var output_path = encodeURIComponent(obj['output_path']);
         var status = obj['status'];
         var run_time = obj['run_time'];
         var start_time = obj['start_time'];

--- a/includes/src/Report/Table.jsx
+++ b/includes/src/Report/Table.jsx
@@ -56,7 +56,7 @@ class Table extends React.PureComponent {
 
     render() {
         var obj = this.props.obj;
-        var output_path = encodeURIComponent(obj['output_path']);
+        var output_path = encodeURIComponent(obj['output_path']) + "/";
         var status = obj['status'];
         var run_time = obj['run_time'];
         var start_time = obj['start_time'];


### PR DESCRIPTION
Fix issue when target url contains reserved characters (like questionmark)

## Description

There is an issue with the fileserver and the encoding when a target contains special characters. E.g: http://192.168.0.14/mutillidae/index.php?page=user-info.php

This tiny commit fixes it :)
