### PR TITLE
Fix responsive menu removing class in target menu which caused issues

### DIFF
--- a/framework/interface/templates/base.html
+++ b/framework/interface/templates/base.html
@@ -145,7 +145,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav navbar-right">
                     <li><a href="{{ reverse_url('dashboard_ui_url') }}"><i class="fa fa-tachometer"></i> Dashboard</a></li>
-                    <li><a href="{{ reverse_url('targets_ui_url', None) }}" class="target-tab"><i class="fa fa-crosshairs"></i> Targets</a></li>
+                    <li><a href="{{ reverse_url('targets_ui_url', None) }}"><i class="fa fa-crosshairs"></i> Targets</a></li>
                     <li><a href="{{ reverse_url('workers_ui_url', None) }}"><i class="fa fa-th-large"></i> Workers</a></li>
                     <li><a href="{{ reverse_url('worklist_ui_url') }}"><i class="fa fa-bars"></i> Worklist</a></li>
                     <li><a href="{{ reverse_url('configuration_ui_url') }}"><i class="fa fa-gears"></i> Settings</a></li>


### PR DESCRIPTION
Removes a css class "target-tab", the only <a> element in the menu with a class attribute, which causes the menu to render wrong in small screens as the screenshot shows. Also, clicking on the "target" menu did nothing (the link didn't work).

## Screenshots (if appropriate):

<img width="543" alt="screen shot 2017-07-30 at 1 23 23 am" src="https://user-images.githubusercontent.com/153092/28808756-8ba39094-764c-11e7-8868-20baae33453a.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)