### PR TITLE
Exception fix for GetAll function in framework/db/poutput_manager.py

### DIFF
--- a/framework/db/target_manager.py
+++ b/framework/db/target_manager.py
@@ -74,7 +74,7 @@ class TargetDB(BaseComponent, TargetInterface):
             self.TargetConfig = self.GetTargetConfigForID(target_id)
             self.PathConfig = self.DerivePathConfig(self.TargetConfig)
         except InvalidTargetReference:
-            pass
+            raise InvalidTargetReference("Target doesn't exist: %s" % str(target_id))
 
     def DerivePathConfig(self, target_config):
         path_config = {}


### PR DESCRIPTION
Let `GetAll` function in `framework/db/poutput_manager.py` raise `InvalidTargetReference` if target not found.

## Reviewers
@viyatb @DePierre @7a 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other
