### PR TITLE
Fixes the Advance filter, mapping filter bug

### DIFF
--- a/framework/db/mapping_manager.py
+++ b/framework/db/mapping_manager.py
@@ -74,6 +74,15 @@ class MappingDB(BaseComponent, MappingDBInterface):
         """
         return self.mapping_types
 
+    def get_all_mappings(self):
+        """Create a mapping between OWTF plugins code and OWTF plugins description.
+
+        :return: Mapping dictionary {code: [mapped_code, mapped_description], code2: [mapped_code, mapped_description], ...}
+        :rtype: dict
+        """
+        mapping_objs = self.db.session.query(models.Mapping).all()
+        return {mapping['owtf_code']: mapping['mappings'] for mapping in self.DeriveMappingDicts(mapping_objs)}
+
     def GetMappings(self, mapping_type):
         if mapping_type in self.mapping_types:
             mapping_objs = self.db.session.query(models.Mapping).all()

--- a/framework/interface/urls.py
+++ b/framework/interface/urls.py
@@ -33,7 +33,7 @@ def get_handlers():
         tornado.web.url(r'/api/targets/([0-9]+)/transactions/search/?$', api_handlers.TransactionSearchHandler, name='transactions_search_api_url'),
         tornado.web.url(r'/api/targets/([0-9]+)/transactions/hrt/?([0-9]+)?/?$', api_handlers.TransactionHrtHandler, name='transactions_hrt_api_url'),
         tornado.web.url(r'/api/targets/([0-9]+)/poutput/?' + plugin_group_re + '/?' + plugin_type_re + '/?' + plugin_code_re + '/?$', api_handlers.PluginOutputHandler, name='poutput_api_url'),
-        tornado.web.url(r'/api/targets/([0-9]+)/poutput/names/?' + plugin_group_re + '/?' + plugin_type_re + '/?' + plugin_code_re + '/?$', api_handlers.PluginNameOutput, name='plugin_name_api_url'),
+        tornado.web.url(r'/api/targets/([0-9]+)/poutput/names/?$', api_handlers.PluginNameOutput, name='plugin_name_api_url'),
         tornado.web.url(r'/api/targets/([0-9]+)/export/?$', api_handlers.ReportExportHandler, name='report_export_api_url'),
 
         # The following one url is dummy and actually processed in file server

--- a/webui/src/Report/Accordian.jsx
+++ b/webui/src/Report/Accordian.jsx
@@ -277,6 +277,7 @@ class Accordian extends React.Component {
         var selectedGroup = this.context.selectedGroup;
         var selectedOwtfRank = this.context.selectedOwtfRank;
         var selectedStatus = this.context.selectedStatus;
+        var mapping = this.context.selectedMapping;
         var handlePluginBtnOnAccordian = this.handlePluginBtnOnAccordian;
         var isClicked = this.state.isClicked;
         if (count > 0) {
@@ -334,7 +335,14 @@ class Accordian extends React.Component {
                                     <a data-toggle="collapse" data-parent="#pluginOutputs" href={"#" + code} onClick={this.fetchData.bind(this, pactive)}>
                                         <h4 style={{
                                             padding: '15px'
-                                        }}>{details['mapped_code'] + ' ' + details['mapped_descrip']}
+                                        }}>
+                                            {(() => {
+                                                if (mapping === "" || (details['mappings'][mapping] === undefined)) {
+                                                    return details['code'] + " " + details['descrip'];
+                                                } else {
+                                                    return details['mappings'][mapping][0] + " " + details['mappings'][mapping][1];
+                                                }
+                                            })()}
                                             <small>{" " + details['hint']}</small>
                                         </h4>
                                     </a>
@@ -382,7 +390,8 @@ Accordian.contextTypes = {
     selectedRank: React.PropTypes.array,
     selectedGroup: React.PropTypes.array,
     selectedOwtfRank: React.PropTypes.array,
-    selectedStatus: React.PropTypes.array
+    selectedStatus: React.PropTypes.array,
+    selectedMapping: React.PropTypes.string
 };
 
 Accordian.childContextTypes = {


### PR DESCRIPTION
Fixes the mapping filtering.

## Description
Fix adds mapping object with `/names` APIs which then used to filter mapping on client side only.

## Related Issue
#695 

## Reviewers
@viyatb @7a @DePierre 

## Screenshots (if appropriate):
![screenshot from 2017-08-16 19-51-24](https://user-images.githubusercontent.com/11960067/29368075-562190fc-82bc-11e7-80cb-430d95f4bb02.png)
![screenshot from 2017-08-16 19-51-26](https://user-images.githubusercontent.com/11960067/29368076-5629134a-82bc-11e7-96e4-a0e61df88986.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other
