### PR TITLE
Tiny Fixes: Font-awesome not being loaded after a fresh install. PTP upgrade.

### DIFF
--- a/owtf/webui/scss/main.scss
+++ b/owtf/webui/scss/main.scss
@@ -4,11 +4,11 @@
  */
 
 /* Importing font-awesome */
-$fa-font-path: "~/static/build/fonts"; // Path of
+$fa-font-path: "/static/build/fonts"; // Path of
 @import "~font-awesome/scss/font-awesome.scss";
 
 /* Importing bootstrap */
-$icon-font-path: "~/static/build/fonts";
+$icon-font-path: "/static/build/fonts";
 @import "~bootstrap-sass/assets/stylesheets/_bootstrap.scss";
 
 @import "vendor/dataTables.bootstrap.scss";

--- a/owtf/webui/src/main.js
+++ b/owtf/webui/src/main.js
@@ -1,3 +1,8 @@
+// FIXME: following line of code generates /font folder
+// there are better ways of doing this but whitout this
+// font-awesome is not being loaded in a fresh install
+import "font-awesome/css/font-awesome.css";
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Home from './Home/Home.jsx';

--- a/owtf/webui/webpack.config.js
+++ b/owtf/webui/webpack.config.js
@@ -72,7 +72,7 @@ var config = merge(common, {
                 loader: ExtractTextPlugin.extract(['css-loader', 'sass-loader'])
             },
             {
-                test: /.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
+                test: /.(ttf|otf|eot|svg|woff(2)?)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
                 use: [{
                     loader: 'file-loader',
                     options: {

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pyasn1==0.3.2
 pexpect==4.2.1
 psutil==5.3.1
 psycopg2==2.7.1
-PTP==0.4.1
+PTP==0.4.2
 pycurl==7.43.0
 pyOpenSSL==17.2.0
 PyVirtualDisplay==0.2.1


### PR DESCRIPTION
Fix font-awesome not being loading after a fresh install issue.
Also upgrade PTP dependency to 0.4.2. Old PTP version caused errors with some plugins.