### PR TITLE
Fix general.cfg and ~/.owtf beeing overwritten

### DIFF
--- a/owtf/data/conf/general.cfg
+++ b/owtf/data/conf/general.cfg
@@ -57,12 +57,12 @@ TOOL_THEHARVESTER_DIR: /usr/share/theharvester
 TOOL_METAGOOFIL_DIR: /usr/share/metagoofil
 # Backtrack 5 R1, no longer working in Backtrack 5 R2:
 #TOOL_HTTPRINT_DIR: /pentest/enumeration/www/httprint/linux
-TOOL_HTTPRINT_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/httprint/httprint_301/linux
+TOOL_HTTPRINT_DIR: ~/.owtf/tools/restricted/httprint/httprint_301/linux
 TOOL_WAFW00F: /usr/bin/wafw00f
 TOOL_NMAP: /usr/bin/nmap
 TOOL_WHATWEB: /usr/bin/whatweb
-#TOOL_WHATWEB: @@@FRAMEWORK_DIR@@@/tools/restricted/whatweb/whatweb-0.4.7/whatweb
-TOOL_CMS_EXPLORER_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/cms-explorer/cms-explorer-1.0
+#TOOL_WHATWEB: ~/.owtf/tools/restricted/whatweb/whatweb-0.4.7/whatweb
+TOOL_CMS_EXPLORER_DIR: ~/.owtf/tools/restricted/cms-explorer/cms-explorer-1.0
 TOOL_LBD: /usr/bin/lbd
 #TOOL_REV_HOSTS_DIR: /pentest/enumeration/web/revhosts
 TOOL_DNS_RECON: /usr/bin/dnsrecon
@@ -71,11 +71,11 @@ TOOL_UA_TESTER: /usr/bin/ua-tester
 TOOL_SKIPFISH_BIN: /usr/bin/skipfish
 TOOL_SKIPFISH_DIR: /usr/share/skipfish/
 #Ran out of time to give this a proper shot:
-#TOOL_ARACHNI_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/arachni-v0.4.1/arachni-0.4.1/bin
-#TOOL_ARACHNI_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/arachni-v0.3-cde
+#TOOL_ARACHNI_DIR: ~/.owtf/tools/restricted/arachni-v0.4.1/arachni-0.4.1/bin
+#TOOL_ARACHNI_DIR: ~/.owtf/tools/restricted/arachni-v0.3-cde
 TOOL_ARACHNI_BIN: /usr/share/arachni/bin/arachni
 TOOL_ARACHNI_REPORTER_BIN: /usr/share/arachni/bin/arachni_reporter
-#TOOL_NIKTO_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/nikto
+#TOOL_NIKTO_DIR: ~/.owtf/tools/restricted/nikto
 # We are patching nikto's poor default user agent in the install script now, 1 tool less to install (in Backtrack!):
 TOOL_NIKTO_BIN: /usr/bin/nikto
 TOOL_NIKTO_DIR: /usr/share/nikto
@@ -87,19 +87,19 @@ TOOL_WAPITI_BIN: /usr/bin/wapiti
 TOOL_DIRBUSTER_BIN: /usr/share/dirbuster/DirBuster-1.0-RC1.jar
 #TOOL_DIRBUSTER_DIR: /usr/share/dirbuster
 TOOL_METASPLOIT_DIR: /usr/share/metasploit-framework
-TOOL_HOPPY_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/hoppy-1.8.1/hoppy-1.8.1
+TOOL_HOPPY_DIR: ~/.owtf/tools/restricted/hoppy-1.8.1/hoppy-1.8.1
 TOOL_WPSCAN: /usr/bin/wpscan
 TOOL_HYDRA: /usr/bin/hydra
 TOOL_TLSSLED: /usr/bin/tlssled
-TOOL_SSL_CIPHER_CHECK: @@@FRAMEWORK_DIR@@@/tools/restricted/ssl/ssl-cipher-check/ssl-cipher-check.pl
-TOOL_HTTP_TRACEROUTE: @@@FRAMEWORK_DIR@@@/tools/discovery/web/rev_proxy/HTTP-Traceroute.py
-TOOL_HTTP_DOS_SLOWLORIS: @@@FRAMEWORK_DIR@@@/tools/dos/web/slowloris.pl
-TOOL_HTTP_DOS_HASH_COLLISION: @@@FRAMEWORK_DIR@@@/tools/dos/web/HashCollision-DOS-POC/HashtablePOC.py
-TOOL_PANOPTIC_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/Panoptic
-TOOL_DNSPIDER: @@@FRAMEWORK_DIR@@@/tools/restricted/dnspider/dnsspider-0.6.py
-TOOL_DNSPIDER_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/dnspider/
+TOOL_SSL_CIPHER_CHECK: ~/.owtf/tools/restricted/ssl/ssl-cipher-check/ssl-cipher-check.pl
+TOOL_HTTP_TRACEROUTE: ~/.owtf/tools/discovery/web/rev_proxy/HTTP-Traceroute.py
+TOOL_HTTP_DOS_SLOWLORIS: ~/.owtf/tools/dos/web/slowloris.pl
+TOOL_HTTP_DOS_HASH_COLLISION: ~/.owtf/tools/dos/web/HashCollision-DOS-POC/HashtablePOC.py
+TOOL_PANOPTIC_DIR: ~/.owtf/tools/restricted/Panoptic
+TOOL_DNSPIDER: ~/.owtf/tools/restricted/dnspider/dnsspider-0.6.py
+TOOL_DNSPIDER_DIR: ~/.owtf/tools/restricted/dnspider/
 TOOL_O-SAFT_BIN: /usr/bin/o-saft
-TOOL_SSLLABS_SCAN_DIR: @@@FRAMEWORK_DIR@@@/tools/restricted/ssllabs-scan/
+TOOL_SSLLABS_SCAN_DIR: ~/.owtf/tools/restricted/ssllabs-scan/
 
 
 [DICTIONARIES]

--- a/owtf/install/install.cfg
+++ b/owtf/install/install.cfg
@@ -14,7 +14,7 @@ directory =  ~/.owtf/tools/restricted/decoding/cookies
 command = wget --user-agent="Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/15.0" --tries=3 http://www.taddong.com/tools/BIG-IP_cookie_decoder.zip; unzip *.zip; rm -f *.zip
 
 [Hoppy]
-directory = ~/.owtfs/tools/restricted/hoppy-1.8.1
+directory = ~/.owtf/tools/restricted/hoppy-1.8.1
 command = wget --user-agent="Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/15.0" --tries=3 https://labs.portcullis.co.uk/download/hoppy-1.8.1.tar.bz2; bunzip2 *; tar xvf *; rm -f *.tar 2> /dev/null
 
 [SSL cipher Check]

--- a/owtf/install/install.py
+++ b/owtf/install/install.py
@@ -8,6 +8,8 @@ The main install script
 import os
 import sys
 import logging
+import shutil
+
 try:
     import configparser as parser
 except ImportError:
@@ -109,8 +111,8 @@ def copy_dirs(root, dir):
     target_src_dir = os.path.join(root, 'data', dir)
     target_dest_dir = os.path.join(dest_root, dir)
     # check if already exists
-    FileOperations.create_missing_dirs(target_dest_dir)
-    dir_util.copy_tree(target_src_dir, target_dest_dir)
+    if not os.path.exists(target_dest_dir):
+        shutil.copytree(target_src_dir, target_dest_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Fix general.cfg tools pointing to old path. 
2. Fix ~/.owtf beeing overwritten every install.
3. Also, hoppy install path pointed to ~/.owtfs instead of ~/.owtf

