### PR TITLE
Add more fine-grained CORS control in the worker handler

### DIFF
--- a/owtf/api/handlers/work.py
+++ b/owtf/api/handlers/work.py
@@ -3,13 +3,12 @@ owtf.api.handlers.work
 ~~~~~~~~~~~~~~~~~~~~~~
 
 """
-import logging
-
 import tornado.gen
 import tornado.httpclient
 import tornado.web
 
 from owtf.api.handlers.base import APIRequestHandler
+from owtf.api.utils import _filter_headers
 from owtf.lib import exceptions
 from owtf.lib.exceptions import APIError
 from owtf.managers.plugin import get_all_plugin_dicts
@@ -17,6 +16,7 @@ from owtf.managers.target import get_target_config_dicts
 from owtf.managers.worker import worker_manager
 from owtf.managers.worklist import add_work, delete_all_work, get_all_work, get_work, \
     patch_work, pause_all_work, remove_work, resume_all_work, search_all_work
+from owtf.settings import ALLOWED_METHODS, SIMPLE_HEADERS, ALLOWED_ORIGINS, SEND_CREDENTIALS
 from owtf.utils.strings import str2bool
 
 __all__ = ['WorkerHandler', 'WorklistHandler', 'WorklistSearchHandler']
@@ -155,14 +155,38 @@ class WorkerHandler(APIRequestHandler):
 
         .. sourcecode:: http
 
-            HTTP/1.1 200 OK
+            HTTP/1.1 204 No Content
             Content-Length: 0
-            Access-Control-Allow-Origin: *
+            Access-Control-Allow-Origin: http://localhost:8009, http://localhost:8010
             Access-Control-Allow-Methods: GET, POST, DELETE
             Content-Type: text/html; charset=UTF-8
         """
-        self.set_status(200)
+        self.set_header('Allow', ','.join(ALLOWED_METHODS))
+        self.set_status(204)
+        if 'Origin' in self.request.headers:
+            if self._cors_preflight_checks():
+                self._build_preflight_response(self.request.headers)
+            else:
+                self.set_status(403)
         self.finish()
+
+    def _cors_preflight_checks(self):
+        try:
+            origin = self.request.headers['Origin']
+            method = self.request.headers['Access-Control-Request-Method']
+            headers = self.request.headers.get('Access-Control-Request-Headers', '')
+        except KeyError:
+            return False
+
+        headers = _filter_headers(headers, SIMPLE_HEADERS)
+        return (origin in ALLOWED_ORIGINS and method in ALLOWED_METHODS and len(headers) == 0)
+
+    def _build_preflight_response(self, headers):
+        self.set_header('Access-Control-Allow-Origin', headers['Origin'])
+        self.set_header('Access-Control-Allow-Methods', ','.join(ALLOWED_METHODS))
+        self.set_header('Access-Control-Allow-Headers', ','.join(headers.keys() - SIMPLE_HEADERS))
+        if SEND_CREDENTIALS:
+            self.set_header('Access-Control-Allow-Credentials', 'true')
 
     def delete(self, worker_id=None, action=None):
         """Delete a worker.

--- a/owtf/api/utils.py
+++ b/owtf/api/utils.py
@@ -4,6 +4,7 @@ owtf.api.utils
 
 """
 from tornado.routing import Matcher
+from tornado.web import RequestHandler
 
 
 class VersionMatches(Matcher):
@@ -21,3 +22,14 @@ class VersionMatches(Matcher):
             return {}
 
         return None
+
+
+def _filter_headers(header_str, simple_headers):
+    header_str = header_str.lower().replace(' ', '').replace('\t', '')
+    if not header_str:
+        return set()
+
+    header_set = set(value for value in header_str.split(','))
+    header_set.difference_update(simple_headers)
+    header_set.difference_update('')
+    return header_set

--- a/owtf/filesrv/handlers.py
+++ b/owtf/filesrv/handlers.py
@@ -21,8 +21,8 @@ __all__ = ['StaticFileHandler']
 class StaticFileHandler(tornado.web.StaticFileHandler):
 
     def set_default_headers(self):
-        self.add_header("Access-Control-Allow-Origin", "*")
-        self.add_header("Access-Control-Allow-Methods", "GET, POST, DELETE")
+        self.add_header("Access-Control-Allow-Origin", '*')
+        self.add_header("Access-Control-Allow-Methods", 'GET')
 
     def get(self, path, include_body=True):
         """
@@ -82,7 +82,7 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             cache_time = self.get_cache_time(path, modified, mime_type)
             if cache_time > 0:
                 self.set_header("Expires", datetime.datetime.utcnow() + datetime.timedelta(seconds=cache_time))
-                self.set_header("Cache-Control", "max-age=%s" % str(cache_time))
+                self.set_header("Cache-Control", "max-age={}".format(str(cache_time)))
             else:
                 self.set_header("Cache-Control", "public")
 
@@ -107,7 +107,7 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
 
             hasher = hashlib.sha1()
             hasher.update(data)
-            self.set_header("Etag", '"%s"' % hasher.hexdigest())
+            self.set_header("Etag", '"{}"'.format(hasher.hexdigest()))
             if include_body:
                 self.write(data)
             else:

--- a/owtf/filesrv/main.py
+++ b/owtf/filesrv/main.py
@@ -9,6 +9,7 @@ import tornado.httpserver
 import tornado.ioloop
 import tornado.options
 
+from owtf import OWTFLogger
 from owtf.filesrv.routes import HANDLERS
 from owtf.managers.worker import worker_manager
 from owtf.settings import FILE_SERVER_LOG, FILE_SERVER_PORT, SERVER_ADDR, TEMPLATES
@@ -25,6 +26,8 @@ class FileServer():
             self.application = Application(handlers=HANDLERS, template_path=TEMPLATES, debug=False, gzip=True)
             self.server = tornado.httpserver.HTTPServer(self.application)
             self.server.bind(int(FILE_SERVER_PORT), address=SERVER_ADDR)
+            self.logger = OWTFLogger()
+            self.logger.disable_console_logging()
             tornado.options.parse_command_line(
                 args=['dummy_arg', '--log_file_prefix={}'.format(FILE_SERVER_LOG), '--logging=info'])
             self.server.start()

--- a/owtf/settings.py
+++ b/owtf/settings.py
@@ -56,6 +56,12 @@ FILE_SERVER_PORT = 8010
 # Default API version
 DEFAULT_API_VERSION = 'v1'
 
+# CORS settings. Fine grained, do not override if possible.
+SIMPLE_HEADERS = ['accept', 'accept-language', 'content-language']
+ALLOWED_ORIGINS = ['http:/localhost:8009', 'http://localhost:8010']
+ALLOWED_METHODS = ['GET', 'POST', 'DELETE']
+SEND_CREDENTIALS = False
+
 # ERROR reporting
 USE_SENTRY = False
 SENTRY_API_KEY = ''

--- a/owtf/utils/http.py
+++ b/owtf/utils/http.py
@@ -3,12 +3,10 @@ owtf.utils.http
 ~~~~~~~~~~~~~~~
 
 """
-
 import collections
 import inspect
 import types
 from functools import wraps
-
 try:  # PY3
     from urllib.parse import urlparse
 except ImportError:  # PY2


### PR DESCRIPTION
This PR provides fine-grained CORS control for the API access to workers. Taken mostly from https://github.com/sprockets/sprockets.mixins.cors/blob/master/sprockets/mixins/cors.py. 