### PR TITLE
Small updates to Wapiti

### DIFF
--- a/owtf/data/conf/general.cfg
+++ b/owtf/data/conf/general.cfg
@@ -80,7 +80,7 @@ TOOL_ARACHNI_REPORTER_BIN: /usr/share/arachni/bin/arachni_reporter
 TOOL_NIKTO_BIN: /usr/bin/nikto
 TOOL_NIKTO_DIR: /usr/share/nikto
 TOOL_W3AF_BIN: /usr/share/w3af/w3af_console
-TOOL_WAPITI_BIN: /usr/bin/wapiti
+TOOL_WAPITI_BIN: /usr/local/bin/wapiti
 # BackTrack:
 #TOOL_DIRBUSTER_BIN: DirBuster-0.12.jar
 # Kali Linux:

--- a/owtf/scripts/run_wapiti.sh
+++ b/owtf/scripts/run_wapiti.sh
@@ -13,7 +13,7 @@ DATE=$(date +%F_%R_%S | sed 's/:/_/g')
 OUTPUTFILE="wapiti_report$DATE"
 DIR=$(pwd)
 FORMAT="xml"
-COMMAND="$TOOL_BIN $URL -f $FORMAT --output $OUTPUTFILE.$FORMAT"
+COMMAND="$TOOL_BIN -u $URL/ -f $FORMAT --output $OUTPUTFILE.$FORMAT"
 
 echo "[*] Running: $COMMAND"
 


### PR DESCRIPTION

1. Changed Wapiti install directory
2. Updated run_wapiti.sh to include new version 3 requirements 
## Description

Wapiti is now installed in  /usr/local/bin/wapiti
-u [url] and it needs to include a forward slash...

## Motivation and Context
Updates to allow Wapiti to function under Kali 2018.2

## Reviewers
@viyatb 

## How Has This Been Tested?
Updated owtf-docker and added these small changes to it.
Installed and tested via 

`docker build -t owtf .`
`docker run -it -p 8008:8008 -p 8009:8009 -p 8010:8010 owtf /bin/bash`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
