### PR TITLE
This fixes the following scenario:

### DIFF
--- a/owtf/__init__.py
+++ b/owtf/__init__.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import, unicode_literals
 import re
 from typing import Any, NamedTuple
 
-from owtf.utils.logger import OWTFLogger
+try:
+    from owtf.utils.logger import OWTFLogger
+    OWTFLogger().enable_logging()
+except ModuleNotFoundError as e:
+    print(e)
 
 __version__ = "2.6.0"
 __homepage__ = "https://github.com/owtf/owtf"
@@ -24,6 +28,3 @@ _temp = re.match(r"(\d+)\.(\d+).(\d+)(\.(.+))?", __version__).groups()
 VERSION = version_info = version_info_t(int(_temp[0]), int(_temp[1]), int(_temp[2]))
 del _temp
 __all__ = []
-
-
-OWTFLogger().enable_logging()

--- a/owtf/__init__.py
+++ b/owtf/__init__.py
@@ -5,8 +5,9 @@ from typing import Any, NamedTuple
 
 try:
     from owtf.utils.logger import OWTFLogger
+
     OWTFLogger().enable_logging()
-except ModuleNotFoundError as e:
+except ImportError as e:
     print(e)
 
 __version__ = "2.6.0"
@@ -14,13 +15,7 @@ __homepage__ = "https://github.com/owtf/owtf"
 __docformat__ = "markdown"
 
 
-version_info_t = NamedTuple(
-    "version_info_t", [
-        ("major", int),
-        ("minor", int),
-        ("patch", int),
-    ]
-)
+version_info_t = NamedTuple("version_info_t", [("major", int), ("minor", int), ("patch", int)])
 
 # bumpversion can only search for {current_version}
 # so we have to parse the version here.


### PR DESCRIPTION
When user is installing owtf and doesn't have tornado installed in its own system, when importing __version__ on setup.py, it will try to load OWTFLogger, that uses tornado, then breaking the application.

My fix just bypass that by handling the LoadModule error and installation goes fine.


## How Has This Been Tested?
Tested on OSX 10.12


## Screenshots (if appropriate):
Before:
![Screen Shot 2019-04-02 at 23 24 58](https://user-images.githubusercontent.com/161360/55448568-9e449800-559e-11e9-8ab7-6049b5c7f2ba.jpg)

After:
It's working!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
