### PR TITLE
Dockerfile Fixed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-linux-docker:latest
+FROM kalilinux/kali-rolling:latest
 
 LABEL Viyat Bhalodia viyat.bhalodia@owasp.org
 


### PR DESCRIPTION
Outdated kali-linux-docker image replaced with the new kali-rollling image. Fixes the permission denied error while building the owtf docker image.