### PR TITLE
Change Version sqlalchemy_mixins==1.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,5 +19,5 @@ requests==2.18.4
 selenium==3.4.3
 six==1.10.0
 SQLAlchemy==1.1.13
-sqlalchemy_mixins==1.1
+sqlalchemy_mixins==1.0.1
 tornado==5.0.2


### PR DESCRIPTION
## Description
sqlalchemy_mixins==1.1 is no longer available in PyPI

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owtf/owtf/issues/1056


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other


