### PR TITLE
Fix Issue #1060

### DIFF
--- a/owtf/api/handlers/plugin.py
+++ b/owtf/api/handlers/plugin.py
@@ -193,7 +193,7 @@ class PluginNameOutput(APIRequestHandler):
 
             dict_to_return = {}
             for item in results:
-                if dict_to_return.has_key(item["plugin_code"]):
+                if item["plugin_code"] in dict_to_return:
                     dict_to_return[item["plugin_code"]]["data"].append(item)
                 else:
                     ini_list = []


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
has_keys() has been removed in Python 3.x.

## Description
<!--- Describe your changes in detail -->
The dict.has_key() method, long deprecated in favour of the "in" operator, is no longer available in Python 3.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owtf/owtf/issues/1060


## Screenshots (if appropriate):
<!--- Before the change and after the change. -->
Before
![Screenshot from 2020-04-24 05-26-19](https://user-images.githubusercontent.com/52630129/80203332-a1487580-8644-11ea-8bc4-0729b9f33fdf.png)
After
![Screenshot from 2020-04-24 05-27-46](https://user-images.githubusercontent.com/52630129/80203383-b0c7be80-8644-11ea-81e6-283147b541b3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

