### PR TITLE
Fix(#1071)Deprecation and SSL compatibility for python3.7

### DIFF
--- a/owtf/proxy/proxy.py
+++ b/owtf/proxy/proxy.py
@@ -35,7 +35,14 @@ class ProxyHandler(tornado.web.RequestHandler):
     """This RequestHandler processes all the requests that the application received."""
 
     SUPPORTED_METHODS = [
-        "GET", "POST", "CONNECT", "HEAD", "PUT", "DELETE", "OPTIONS", "TRACE"
+        "GET",
+        "POST",
+        "CONNECT",
+        "HEAD",
+        "PUT",
+        "DELETE",
+        "OPTIONS",
+        "TRACE",
     ]
     server = None
     restricted_request_headers = None
@@ -307,7 +314,7 @@ class ProxyHandler(tornado.web.RequestHandler):
         # Hacking to be done here, so as to check for ssl using proxy and auth
         try:
             # Adds a fix for check_hostname errors in Tornado 4.3.0
-            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.check_hostname = False
             context.load_default_certs()
             # When connecting through a new socket, no need to wrap the socket before passing to SSIOStream
@@ -417,9 +424,9 @@ class CustomWebSocketHandler(tornado.websocket.WebSocketHandler):
         :rtype: None
         """
         try:  # Cannot write binary content as a string, so catch it
-            self.handshake_request.response_buffer += (">>> {}\r\n".format(message))
+            self.handshake_request.response_buffer += ">>> {}\r\n".format(message)
         except TypeError:
-            self.handshake_request.response_buffer += (">>> May be binary\r\n")
+            self.handshake_request.response_buffer += ">>> May be binary\r\n"
 
     def store_downstream_data(self, message):
         """Save websocket data sent from client to server.
@@ -431,9 +438,9 @@ class CustomWebSocketHandler(tornado.websocket.WebSocketHandler):
         :rtype: None
         """
         try:  # Cannot write binary content as a string, so catch it.
-            self.handshake_request.response_buffer += ("<<< {}\r\n".format(message))
+            self.handshake_request.response_buffer += "<<< {}\r\n".format(message)
         except TypeError:
-            self.handshake_request.response_buffer += ("<<< May be binary\r\n")
+            self.handshake_request.response_buffer += "<<< May be binary\r\n"
 
     def on_message(self, message):
         """Everytime a message is received from client side, this instance method is called.
@@ -466,7 +473,9 @@ class CustomWebSocketHandler(tornado.websocket.WebSocketHandler):
         if not self.upstream.read_future:
             self.upstream.read_message(callback=self.on_response)
         if self.ws_connection:  # Check if connection still exists.
-            if message.result():  # Check if it is not NULL (indirect checking of upstream connection).
+            if (
+                message.result()
+            ):  # Check if it is not NULL (indirect checking of upstream connection).
                 self.write_message(
                     message.result()
                 )  # Write obtained message to client.
@@ -500,7 +509,6 @@ class CustomWebSocketHandler(tornado.websocket.WebSocketHandler):
 
 
 class CustomWebSocketClientConnection(tornado.websocket.WebSocketClientConnection):
-
     def _handle_1xx(self, code):
         """Had to extract response code, so it is necessary to override.
 

--- a/owtf/proxy/socket_wrapper.py
+++ b/owtf/proxy/socket_wrapper.py
@@ -51,7 +51,7 @@ def starttls(
 
     # # Default Options
     options.setdefault("do_handshake_on_connect", False)
-    options.setdefault("ssl_version", ssl.PROTOCOL_SSLv23)
+    options.setdefault("ssl_version", ssl.PROTOCOL_TLS)
     options.setdefault("server_side", True)
 
     # The idea is to handle domains with greater than 3 dots using wildcard certs
@@ -118,7 +118,12 @@ def starttls(
     state = [io.ERROR]
     # Wrap the socket; swap out handlers.
     io.remove_handler(socket.fileno())
-    wrapped = ssl.SSLSocket(socket, **options)
+    try:
+        wrapped = ssl.wrap_socket(socket, **options)
+    except TypeError:
+        # if python version less than 3.7
+        wrapped = ssl.SSLSocket(socket, **options)
+
     wrapped.setblocking(0)
     io.add_handler(wrapped.fileno(), handshake, state[0])
     # Begin the handshake.


### PR DESCRIPTION
## Description

`ssl.PROTOCOL_SSLv23` deprecated since version 3.6: Use `PROTOCOL_TLS `instead.
Use `ssl.wrap_socket` in version python3.7  and `ssl.SSLSocket` in version python3.6 and below.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owtf/owtf/issues/1071

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@viyatb @sharmamohit123 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
