### PR TITLE
Setup.py Fails because certain needs to be installed manually

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,24 @@ import codecs
 import os
 from subprocess import call
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from distutils.core import setup, find_packages
+from setuptools import setup, find_packages
+
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 
-from owtf import __version__
 
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+# Extracts the version details
+def get_version(init_path):
+    # Read the __init__ file
+    with open(init_path, "r+") as f:
+        init_page = f.read()
+    # Extract the version from the init file
+    for each_line in init_page.splitlines():
+        if each_line.startswith("__version__"):
+            delimiter = '"' if '"' in each_line else "'"
+            return each_line.split(delimiter)[1]
 
 
 def strip_comments(l):
@@ -40,8 +48,11 @@ def reqs(*f):
     return [req for subreq in _reqs(*f) for req in subreq]
 
 
+# Absolute path for README.md
+readme_md = read_me = os.path.join(ROOT_DIR, "README.md")
+
 # Long description
-long_description = codecs.open("README.md", "r", "utf-8").read()
+long_description = codecs.open(os.path.abspath("README.md"), "r", "utf-8").read()
 
 post_script = os.path.join(ROOT_DIR, "scripts/install.sh")
 
@@ -67,7 +78,7 @@ class PostInstallCommand(install):
 
 setup(
     name="owtf",
-    version=__version__,
+    version=get_version("owtf/__init__.py"),
     url="https://github.com/owtf/owtf",
     license="BSD",
     author="Abraham Aranguren",


### PR DESCRIPTION
<!--- Provide a general, concise summary of your changes in the Title above -->
On running `python setup.py develop` a ModuleNotFoundError is thrown, due to which the installation process fails.
The reason being `"from owtf import __version"` imports packages from `install_requires dependencies `which are not yet installed
We have to manually install the following Modules Tornado, PyYAML, Six, and then run `python setup.py develop` again to complete the installation process.

## Description
<!--- Describe your changes in detail -->
Instead of importing the version number, the code the version will now extract it from init.py

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owtf/owtf/issues/1057

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To install OWTF, without the user manually needing to install the required dependent modules.

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@viyatb @sharmamohit123 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style (modified PEP8) of this project.

