### PR TITLE
docs: fix simple typo, intersting -> interesting

### DIFF
--- a/owtf/data/tools/discovery/web/rev_proxy/HTTP-Traceroute.py
+++ b/owtf/data/tools/discovery/web/rev_proxy/HTTP-Traceroute.py
@@ -259,7 +259,7 @@ def debug_and_parse(data):
         zprint(str(headers), "DEBUG HEADERS")
         zprint(str(body), "DEBUG BODY")
 
-    # Extract some intersting info
+    # Extract some interesting info
     codes = server.BaseHTTPRequestHandler.responses
     global_data["StatusCode"][hop] = str(data.code) + " " + codes[data.code][0]
     analyse_headers(headers)


### PR DESCRIPTION
There is a small typo in owtf/data/tools/discovery/web/rev_proxy/HTTP-Traceroute.py.

Should read `interesting` rather than `intersting`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md