### PR TITLE
Filter work allowing deleting/resuming/pausing selected work lists.

### DIFF
--- a/owtf/webapp/src/containers/WorklistPage/WorklistTable.js
+++ b/owtf/webapp/src/containers/WorklistPage/WorklistTable.js
@@ -5,7 +5,7 @@
  */
 import React from "react";
 import { filter } from "fuzzaldrin-plus";
-import { Table, IconButton, Link, Tooltip } from "evergreen-ui";
+import { Table, IconButton, Link, Tooltip, Checkbox } from "evergreen-ui";
 import PropTypes from "prop-types";
 
 export default class WorklistTable extends React.Component {
@@ -16,7 +16,8 @@ export default class WorklistTable extends React.Component {
       urlSearch: "", //filter for target URL
       nameSearch: "", //plugin name filter query
       typeSearch: "", //plugin type filter query
-      groupSearch: "" //plugin group filter query
+      groupSearch: "", //plugin group filter query
+      items: {} // stores the filtered items
     };
   }
 
@@ -119,21 +120,34 @@ export default class WorklistTable extends React.Component {
     this.setState({ groupSearch: value });
   };
 
-  render() {
+  /**
+   * Function handling the toggling of the selection checkbox
+   * @param {e, items} value event, items to be selected
+   */
+  toggleCheck = (e, items) => {
+    this.props.changeSelection(e.target.checked);
+    this.props.updatingWorklist(items);
+  };
+
+  render = () => {
     const { worklist, resumeWork, pauseWork, deleteWork } = this.props;
     const items = this.handleTableFilter(worklist);
     return (
       <Table data-test="worklistTableComponent">
-        <Table.Head height={50}>
-          <Table.TextHeaderCell flex="none" width="10%">
-            Est. Time (min)
+        <Table.Head height={55}>
+          <Table.TextHeaderCell flex="none" width="12%">
+            <Checkbox
+              checked={this.props.selection}
+              onChange={(e, item) => this.toggleCheck(e, items)}
+              label="Est. Time (min)"
+            />
           </Table.TextHeaderCell>
           <Table.TextHeaderCell flex="none" width="10%">
             Actions
           </Table.TextHeaderCell>
           <Table.SearchHeaderCell
             flex="none"
-            width="24%"
+            width="22%"
             onChange={this.handleURLFilterChange}
             value={this.state.urlSearch}
             placeholder="Target"
@@ -163,7 +177,7 @@ export default class WorklistTable extends React.Component {
         <Table.VirtualBody height={800}>
           {items.map(work => (
             <Table.Row key={work.id} isSelectable>
-              <Table.TextCell flex="none" width="10%">
+              <Table.TextCell flex="none" width="12%">
                 {work.plugin.min_time}
               </Table.TextCell>
               <Table.Cell flex="none" width="10%">
@@ -192,7 +206,7 @@ export default class WorklistTable extends React.Component {
               </Table.Cell>
               <Table.TextCell
                 flex="none"
-                width="25%"
+                width="23%"
                 title={work.target.target_url}
               >
                 <Link href={`/targets/${work.target.id}`} target="_blank">
@@ -217,7 +231,7 @@ export default class WorklistTable extends React.Component {
         </Table.VirtualBody>
       </Table>
     );
-  }
+  };
 }
 
 WorklistTable.propTypes = {

--- a/owtf/webapp/src/containers/WorklistPage/index.js
+++ b/owtf/webapp/src/containers/WorklistPage/index.js
@@ -37,7 +37,9 @@ export class WorklistPage extends React.Component {
     this.deleteWork = this.deleteWork.bind(this);
 
     this.state = {
-      globalSearch: "" //handles the search query for the main search box
+      globalSearch: "", //handles the search query for the main search box
+      selection: false, // handles selection of checkbox
+      worklist: {} // stores the selected worklist
     };
   }
 
@@ -142,6 +144,52 @@ export class WorklistPage extends React.Component {
     }, 500);
   }
 
+  /**
+   * Function to change state variable worklist
+   * @param {worklist} worklist object with current selected worklist
+   */
+  updatingWorklist = worklist => {
+    this.setState({ worklist: worklist });
+  };
+
+  /**
+   * Function to change state variable selection
+   * @param {val} val (true/false) with which selection should be set
+   */
+  changeSelection = val => {
+    this.setState({ selection: val });
+  };
+
+  /**
+   * Function to delete selected work
+   * Uses Function deleteWork()
+   */
+  deleteSelectedWork = () => {
+    for (let val of this.state.worklist) {
+      this.deleteWork(val.id);
+    }
+  };
+
+  /**
+   * Function to resume selected work
+   * Uses Function resumeWork()
+   */
+  resumeSelectedWork = () => {
+    for (let val of this.state.worklist) {
+      this.resumeWork(val.id);
+    }
+  };
+
+  /**
+   * Function to pause selected work
+   * Uses Function pauseWork()
+   */
+  pauseSelectedWork = () => {
+    for (let val of this.state.worklist) {
+      this.pauseWork(val.id);
+    }
+  };
+
   render() {
     const { fetchLoading, fetchError, worklist } = this.props;
     const WorklistTableProps = {
@@ -186,26 +234,36 @@ export class WorklistPage extends React.Component {
             iconBefore="pause"
             appearance="primary"
             intent="success"
-            onClick={this.pauseAllWork}
+            onClick={
+              !this.state.selection ? this.pauseAllWork : this.pauseSelectedWork
+            }
           >
-            Pause All
+            {!this.state.selection ? "Pause All" : "Pause Selected"}
           </Button>
           <Button
             marginRight={16}
             iconBefore="play"
             appearance="primary"
             intent="warning"
-            onClick={this.resumeAllWork}
+            onClick={
+              !this.state.selection
+                ? this.resumeAllWork
+                : this.resumeSelectedWork
+            }
           >
-            Resume All
+            {!this.state.selection ? "Resume All" : "Resume Selected"}
           </Button>
           <Button
             iconBefore="trash"
             appearance="primary"
             intent="danger"
-            onClick={this.deleteAllWork}
+            onClick={
+              !this.state.selection
+                ? this.deleteAllWork
+                : this.deleteSelectedWork
+            }
           >
-            Delete All
+            {!this.state.selection ? "Delete All" : "Delete Selected"}
           </Button>
         </Pane>
         {fetchError !== false ? (
@@ -228,7 +286,17 @@ export class WorklistPage extends React.Component {
             <Spinner size={64} />
           </Pane>
         ) : null}
-        {worklist !== false ? <WorklistTable {...WorklistTableProps} /> : null}
+        {worklist !== false ? (
+          <WorklistTable
+            {...WorklistTableProps}
+            updatingWorklist={this.updatingWorklist}
+            selection={this.state.selection}
+            changeSelection={this.changeSelection}
+            resumeAllWork={this.resumeAllWork}
+            pauseAllWork={this.pauseAllWork}
+            deleteAllWork={this.deleteAllWork}
+          />
+        ) : null}
       </Pane>
     );
   }


### PR DESCRIPTION
## Description
I have implemented a select functionality that allows the users to select all the worklists after doing a filter by some query in the worklist page. This will allow them to resume/pause/delete only the selected worklists from the complete table of worklists.

## Related Issue
Fixed #822 

## Reviewers
@viyatb @sharmamohit123 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/37950602/111770120-0695fc80-88d0-11eb-8c9b-4e172bfafb7f.png)
![image](https://user-images.githubusercontent.com/37950602/111770170-157caf00-88d0-11eb-8eef-494e386a422c.png)
![image](https://user-images.githubusercontent.com/37950602/111770219-24636180-88d0-11eb-9cbd-cd25dafec7a0.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
