### PR TITLE
warn new docker users about kali rolling-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,22 +88,25 @@ docs:
 docker-build:
 	@echo "--> Building the docker image for develop"
 	@echo "Please note that this uses the kali linux rolling release docker image"
-	@echo "which does not support pinning to a specific version; it only has the `:latest` tag"
-	@echo "So if this docker image build fails, that's probably why"
+	@echo "which does not support pinning to a specific version; it only has the ':latest' tag"
+	@echo "So if this docker image build fails, that probably means OWTF needs"
+	@echo "to update its docker build after a recent kali linux rolling release"
 	docker build -t owtf/owtf -f docker/Dockerfile .
 
 docker-run:
 	@echo "--> Running the Docker development image"
 	@echo "Please note that this uses the kali linux rolling release docker image"
-	@echo "which does not support pinning to a specific version; it only has the `:latest` tag"
-	@echo "So if this docker image build fails, that's probably why"
+	@echo "which does not support pinning to a specific version; it only has the ':latest' tag"
+	@echo "So if this docker image build fails, that probably means OWTF needs"
+	@echo "to update its docker build after a recent kali linux rolling release"
 	docker run -it -p 8009:8009 -p 8008:8008 -p 8010:8010 -v $(current_dir):/owtf owtf/owtf /bin/bash
 
 compose:
 	@echo "--> Running the Docker Compose setup"
 	@echo "Please note that this uses the kali linux rolling release docker image"
-	@echo "which does not support pinning to a specific version; it only has the `:latest` tag"
-	@echo "So if this docker image build fails, that's probably why"
+	@echo "which does not support pinning to a specific version; it only has the ':latest' tag"
+	@echo "So if this docker image build fails, that probably means OWTF needs"
+	@echo "to update its docker build after a recent kali linux rolling release"
 	docker-compose -f docker/docker-compose.dev.yml up
 
 ### DEBIAN PACKAGING

--- a/Makefile
+++ b/Makefile
@@ -87,14 +87,23 @@ docs:
 
 docker-build:
 	@echo "--> Building the docker image for develop"
+	@echo "Please note that this uses the kali linux rolling release docker image"
+	@echo "which does not support pinning to a specific version; it only has the `:latest` tag"
+	@echo "So if this docker image build fails, that's probably why"
 	docker build -t owtf/owtf -f docker/Dockerfile .
 
 docker-run:
 	@echo "--> Running the Docker development image"
+	@echo "Please note that this uses the kali linux rolling release docker image"
+	@echo "which does not support pinning to a specific version; it only has the `:latest` tag"
+	@echo "So if this docker image build fails, that's probably why"
 	docker run -it -p 8009:8009 -p 8008:8008 -p 8010:8010 -v $(current_dir):/owtf owtf/owtf /bin/bash
 
 compose:
 	@echo "--> Running the Docker Compose setup"
+	@echo "Please note that this uses the kali linux rolling release docker image"
+	@echo "which does not support pinning to a specific version; it only has the `:latest` tag"
+	@echo "So if this docker image build fails, that's probably why"
 	docker-compose -f docker/docker-compose.dev.yml up
 
 ### DEBIAN PACKAGING


### PR DESCRIPTION
warn new docker users about kali rolling-release

I added a warning message to all 3 of the docker related commands in the Makefile.

## Description

Here is the message I added: 

> Please note that this uses the kali linux rolling release docker image
> which does not support pinning to a specific version; it only has the `:latest` tag
> So if this docker image build fails, that probably means OWTF needs 
> to update its docker build after a recent kali linux rolling release 

## Related Issue

Right now if you run any of those 3 docker-related make commands they will attempt to perform a docker image build from the provided Dockerfile which references `kalilinux/kali-rolling:latest`.  After this project is left for a few months this build probably rot; `kalilinux/kali-rolling:latest` will be updated to something newer and the old docker build won't work any more.  For example right now it doesn't work because the package named `python3.9` doesn't exist in the kali linux package repo any more. 

## Motivation and Context
This change is required for new users who are not docker experts to be able to tell whats going on when they try to run the tool using docker and the image build part of it fails since  OWTF has been left alone for a while and  `kalilinux/kali-rolling:latest`  changed.   In fact, people may not even realize that it's running a docker build at all, since most projects provide a ready-to-run image as a part of their docker-compose. 

## Reviewers
I don't know anyone to tag here

## How Has This Been Tested?

I haven't tested it at all,  but it's just an echo statement in the makefile.

## Types of changes
- [X] Other  (Usability) 

### Checklist:
- [X] My code follows the code style (modified PEP8) of this project.   ( To be honest I don't feel like reading about the code style here,  It's just echo statements to warn the user ) 
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
