### PR TITLE
Fix issue #1292: Improve check_sudo function and ensure POSIX compliance

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,8 +70,20 @@ create_directory() {
 }
 
 check_sudo() {
-    timeout 2 sudo id && sudo=1 || sudo=0
-    return $sudo
+    # Check if the 'timeout' command is available
+    if ! command -v timeout > /dev/null; then
+        echo "${warning}[!] 'timeout' command not found. Skipping sudo check.${reset}"
+        return 0
+    fi
+
+    # Attempt to check sudo privileges with a timeout
+    if timeout 2 sudo -n true 2>/dev/null; then
+        echo "${info}[*] Sudo privileges are available.${reset}"
+        return 1
+    else
+        echo "${warning}[!] Sudo privileges are not available or require a password.${reset}"
+        return 0
+    fi
 }
 
 check_root() {
@@ -165,8 +177,9 @@ for dir in ${ROOT_DIR}/data/*; do
     copy_dirs "$dir" "${OWTF_DIR}/$(basename $OWTF_DIR/$dir)"
 done
 
-if [ ! "$(uname)" == "Darwin" ]; then
-    check_sudo > /dev/null
+# Solve the issue #1292
+if [ "$(uname)" != "Darwin" ]; then
+    check_sudo
 fi
 
 proxy_setup


### PR DESCRIPTION
## Description
This pull request addresses **issue #1292** by improving the `check_sudo` function and ensuring POSIX compliance in the install.sh script. The changes enhance the script's robustness and cross-platform compatibility.

### Changes Made:
1. **Improved `check_sudo` Function**:
   - Added a check for the availability of the `timeout` command.
   - Provided clear feedback to the user about the status of sudo privileges.
   - Ensured the script does not hang if `sudo` prompts for a password.

2. **Ensured POSIX Compliance**:
   - Replaced `==` with `=` in string comparisons to make the script compatible with POSIX-compliant shells.

---

## Related Issue
This pull request fixes **issue #1292**.  
Link to the issue: [#1292](https://github.com/owtf/owtf/issues/1292)

---

## Motivation and Context
The install.sh script had issues with:
- Non-POSIX-compliant string comparisons (`==`), which caused errors in some environments.
- The `check_sudo` function, which did not handle the absence of the `timeout` command gracefully and could hang if `sudo` prompted for a password.

These changes ensure the script works reliably across different platforms and shells, improving the user experience during installation.

---

## Reviewers
@7a  @viyatb  

---

## How Has This Been Tested?
- Tested the updated install.sh script on:
  - **Linux**: Verified that the `check_sudo` function works as expected with and without the `timeout` command.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

---

### Checklist:
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.