### PR TITLE
Fix: Add missing logger instantiation in proxy/main.py

### DIFF
--- a/owtf/proxy/main.py
+++ b/owtf/proxy/main.py
@@ -3,6 +3,7 @@ owtf.proxy.main
 ~~~~~~~~~~~~~~~
 """
 import logging
+logger = logging.getLogger(__name__)
 import os
 import re
 import socket

--- a/owtf/proxy/main.py
+++ b/owtf/proxy/main.py
@@ -3,7 +3,6 @@ owtf.proxy.main
 ~~~~~~~~~~~~~~~
 """
 import logging
-logger = logging.getLogger(__name__)
 import os
 import re
 import socket
@@ -41,6 +40,7 @@ from owtf.settings import (
 from owtf.utils.error import abort_framework
 from owtf.utils.file import FileOperations
 
+logger = logging.getLogger(__name__)
 
 class ProxyProcess(OWTFProcess):
     def initialize(self, outbound_options=None, outbound_auth=""):


### PR DESCRIPTION
Fixes #1309

**Changes Made**

Added missing logger instantiation in owtf/proxy/main.py after the logging import.

**Problem**

The proxy module was using logger.info() and logger.error() without instantiating a logger object, causing NameError on backend startup.

**Solution**

Added:
`logger = logging.getLogger(__name__)`

**Testing**

Verified that backend starts successfully after this fix in Docker environment.

**Checklist**

- [x] Code follows project style guidelines
- [x] Tested in Docker environment
- [x] Related issue referenced