### PR TITLE
Fix password validation to allow complex 32-char secrets

### DIFF
--- a/owtf/settings.py
+++ b/owtf/settings.py
@@ -147,7 +147,7 @@ REGEXP_SMALL_FILE_URL = "^[^\?]+\.(xml|cs|inc|dat|bak|conf|cnf|old|txt)$"
 REGEXP_IMAGE_URL = "^[^\?]+\.(jpg|jpeg|png|gif|bmp)$"
 REGEXP_VALID_URL = "^[^\?]+\.(shtml|shtm|stm)$"
 REGEXP_SSI_URL = "^(http|ftp)[^ ]+$"
-REGEXP_PASSWORD = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!#%*?&]{8,20}$"
+REGEXP_PASSWORD = r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])\S{8,32}$"
 REGEXP_EMAIL = "^[a-z0-9]+[\._]?[a-z0-9]+[@]\w+[-]?\w+[.]\w{2,3}$"
 
 # Compile regular expressions once at the beginning for speed purposes:

--- a/owtf/webapp/src/containers/NewPasswordPage/index.tsx
+++ b/owtf/webapp/src/containers/NewPasswordPage/index.tsx
@@ -14,68 +14,63 @@ import { AiFillEye } from "react-icons/ai";
 import logo from "../../../public/img/logo.png";
 
 interface propsType {
-  onNewPassword: Function,
-  otp:string,
-  emailOrUsername: string
+  onNewPassword: Function;
+  otp: string;
+  emailOrUsername: string;
 }
 interface stateType {
-  newPassword: string,
-  newConfirmPassword: string,
-  errors: object, 
-  hidePassword: boolean, 
-  hideConfirmPassword: boolean 
+  newPassword: string;
+  newConfirmPassword: string;
+  errors: Record<string, string>;
+  hidePassword: boolean;
+  hideConfirmPassword: boolean;
 }
 
-
-export class NewPasswordPage extends React.Component<propsType, stateType>  {
+export class NewPasswordPage extends React.Component<propsType, stateType> {
   constructor(props, context) {
     super(props, context);
 
     this.state = {
       newPassword: "",
       newConfirmPassword: "",
-      errors: {}, //stores errors during form validation
+      errors: {} as Record<string, string>, //stores errors during form validation
       hidePassword: true, //handles visibility of password input field
       hideConfirmPassword: true //handles visibility of confirmPassword input field
     };
   }
 
-  handlePasswordValidation = e => {
-    // Password
+  handlePasswordValidation = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
     let formIsValid = true;
-    let errors = {};
+    const errors: Record<string, string> = { ...this.state.errors };
 
-    if (e.target.name === "text-input-password" && !this.state.newPassword) {
-      formIsValid = false;
-      errors["newPassword"] = "Password can't be empty";
-    } else if (
-      e.target.name === "text-input-password" &&
-      typeof this.state.newPassword !== "undefined"
-    ) {
-      if (
-        !this.state.newPassword.match(
-          /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9])(?!.*\s).{8,15}$/
+    if (name === "text-input-password") {
+      if (!value) {
+        formIsValid = false;
+        errors["newPassword"] = "Password can't be empty";
+      } else if (
+        !value.match(
+          /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9])(?!.*\s).{8,32}$/
         )
       ) {
         formIsValid = false;
         errors["newPassword"] =
-          "Must have capital, small, number & special chars (8 letters or more)";
+          "Must have capital, small, number & special chars (8-32 characters)";
+      } else {
+        delete errors["newPassword"];
       }
     }
 
-    // Confirm Password
-    if (
-      e.target.name === "text-input-confirm-password" &&
-      !this.state.newConfirmPassword
-    ) {
-      formIsValid = false;
-      errors["newConfirmPassword"] = "Confirm Password can't be empty";
-    } else if (
-      e.target.name === "text-input-confirm-password" &&
-      this.state.newPassword !== this.state.newConfirmPassword
-    ) {
-      formIsValid = false;
-      errors["newConfirmPassword"] = "Password doesn't match";
+    if (name === "text-input-confirm-password") {
+      if (!value) {
+        formIsValid = false;
+        errors["newConfirmPassword"] = "Confirm Password can't be empty";
+      } else if (value !== this.state.newPassword) {
+        formIsValid = false;
+        errors["newConfirmPassword"] = "Password doesn't match";
+      } else {
+        delete errors["newConfirmPassword"];
+      }
     }
 
     this.setState({ errors: errors });
@@ -176,7 +171,6 @@ export class NewPasswordPage extends React.Component<propsType, stateType>  {
     );
   }
 }
-
 
 const mapStateToProps = createStructuredSelector({
   otp: makeSelectCreateOtp,

--- a/owtf/webapp/src/containers/SignupPage/index.tsx
+++ b/owtf/webapp/src/containers/SignupPage/index.tsx
@@ -20,7 +20,7 @@ interface stateType {
   email: string;
   password: string;
   confirmPassword: string;
-  errors: object;
+  errors: Record<string, string>;
   hidePassword: boolean;
   hideConfirmPassword: boolean;
 }
@@ -34,7 +34,7 @@ export class SignupPage extends React.Component<propsType, stateType> {
       email: "", //email of the user to be added
       password: "", //password of the user to be added
       confirmPassword: "", //confirmPassword of the user to be added
-      errors: {}, //stores errors during form validation
+      errors: {} as Record<string, string>, //stores errors during form validation
       hidePassword: true, //handles visibility of password input field
       hideConfirmPassword: true //handles visibility of confirmPassword input field
     };
@@ -45,64 +45,64 @@ export class SignupPage extends React.Component<propsType, stateType> {
    * @param {object} e event which triggered this function
    */
   handleValidation = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
     let formIsValid = true;
-    let errors = {};
+    const errors: Record<string, string> = { ...this.state.errors };
 
-    //Username
-    if (e.target.name === "text-input-name" && !this.state.username) {
-      formIsValid = false;
-      errors["username"] = "Username can't be empty";
+    // Username
+    if (name === "text-input-name") {
+      if (!value) {
+        formIsValid = false;
+        errors["username"] = "Username can't be empty";
+      } else {
+        delete errors["username"];
+      }
     }
 
-    //Email
-    else if (e.target.name === "text-input-email" && !this.state.email) {
-      formIsValid = false;
-      errors["email"] = "Email can't be empty";
-    } else if (
-      e.target.name === "text-input-email" &&
-      typeof this.state.email !== "undefined"
-    ) {
-      if (
-        !this.state.email.match(
-          /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/
-        )
+    // Email
+    if (name === "text-input-email") {
+      if (!value) {
+        formIsValid = false;
+        errors["email"] = "Email can't be empty";
+      } else if (
+        !value.match(/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/)
       ) {
         formIsValid = false;
         errors["email"] = "Please enter a valid email";
+      } else {
+        delete errors["email"];
       }
     }
 
     // Password
-    if (e.target.name === "text-input-password" && !this.state.password) {
-      formIsValid = false;
-      errors["password"] = "Password can't be empty";
-    } else if (
-      e.target.name === "text-input-password" &&
-      typeof this.state.password !== "undefined"
-    ) {
-      if (
-        !this.state.password.match(
-          /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9])(?!.*\s).{8,15}$/
+    if (name === "text-input-password") {
+      if (!value) {
+        formIsValid = false;
+        errors["password"] = "Password can't be empty";
+      } else if (
+        !value.match(
+          /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9])(?!.*\s).{8,32}$/
         )
       ) {
         formIsValid = false;
-        errors["password"] = "Must have capital, small, number & special chars";
+        errors["password"] =
+          "Must have capital, small, number & special chars (8-32 characters)";
+      } else {
+        delete errors["password"];
       }
     }
 
     // Confirm Password
-    if (
-      e.target.name === "text-input-confirm-password" &&
-      !this.state.confirmPassword
-    ) {
-      formIsValid = false;
-      errors["confirmPassword"] = "Confirm Password can't be empty";
-    } else if (
-      e.target.name === "text-input-confirm-password" &&
-      this.state.password !== this.state.confirmPassword
-    ) {
-      formIsValid = false;
-      errors["confirmPassword"] = "Password doesn't match";
+    if (name === "text-input-confirm-password") {
+      if (!value) {
+        formIsValid = false;
+        errors["confirmPassword"] = "Confirm Password can't be empty";
+      } else if (value !== this.state.password) {
+        formIsValid = false;
+        errors["confirmPassword"] = "Password doesn't match";
+      } else {
+        delete errors["confirmPassword"];
+      }
     }
 
     this.setState({ errors: errors });


### PR DESCRIPTION
## Summary
- cap the shared password regex at 8-32 characters on the backend
- update the signup and reset password forms to evaluate the current input value and keep field-specific error state
- align the frontend helper copy with the 8-32 character requirement

## Testing
- python - <<'PY'
import re
pattern = re.compile(r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])\S{8,32}$")
passwords = {
    "valid_32": "Aa0!Bb1@Cc2#Dd3$Ee4%Ff5^Gg6&",
    "valid_8": "Aa1!Bb2@",
    "too_short": "Aa1!Bb",
    "too_long": "Aa0!" * 9,
}
for label, value in passwords.items():
    print(label, bool(pattern.fullmatch(value)), len(value))
PY

------
https://chatgpt.com/codex/tasks/task_e_69042b342c008326bffd34f949f21462