### PR TITLE
Add Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: requirements/docs.txt
+    - requirements: docs/docs-requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
## Summary
- add the missing .readthedocs.yaml configuration file required by Read the Docs
- specify the Sphinx configuration path and documentation dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908e317c3408326a1db396d8d79cc4e