### PR TITLE
Adjust Read the Docs build environment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: requirements/docs.txt
+    - requirements: docs/docs-requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
## Summary
- update the Read the Docs configuration to build documentation with Python 3.8 for compatibility with pinned doc dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908e317c3408326a1db396d8d79cc4e