### PR TITLE
Fix Read the Docs build dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: requirements/docs.txt
+    - requirements: docs/docs-requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,17 @@
 import sys
 import os
 import sphinx_py3doc_enhanced_theme
+import sphinx.util
+
+# Compatibility shim: sphinxcontrib.autohttp.tornado still imports the deprecated
+# ``sphinx.util.force_decode`` helper that was removed in modern Sphinx
+# releases. Provide a minimal implementation so the extension continues to work
+# when building the documentation on Read the Docs.
+if not hasattr(sphinx.util, "force_decode"):
+    def _force_decode(value, encoding="utf-8"):
+        return value.decode(encoding, "ignore") if isinstance(value, bytes) else value
+
+    sphinx.util.force_decode = _force_decode  # type: ignore[attr-defined]
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,23 +1,37 @@
 sphinx
 sphinx_py3doc_enhanced_theme
 sphinxcontrib.httpdomain
--e git+https://github.com/jek/blinker#egg=blinker
-cffi==1.10.0
-cookies==2.2.1
-dnspython==2.6.1
+
+# Align the documentation build dependencies with the runtime pins from
+# requirements/base.txt so that the Read the Docs environment can install the
+# project and its docs tooling under Python 3.11 without version conflicts.
+blinker==1.7.0
+cffi==1.16.0
+dnspython==2.5.0
 future==0.16.0
 hrt==0.1.0
-ipaddr
-Markdown==2.6.9
-pexpect==4.2.1
-psutil==5.6.6
-psycopg2==2.7.4
+ipaddr==2.2.0
+Markdown==3.5.2
+pexpect==4.6.0
+psutil==5.9.4
+psycopg2-binary==2.9.9
 owtf_ptp==0.4.3
-pyOpenSSL==17.2.0
-pyyaml==5.4
-requests==2.18.4
+pycurl==7.45.3
+pyOpenSSL==23.3.0
+PyYAML==6.0.1
+requests==2.31.0
 selenium==3.4.3
-six==1.10.0
-SQLAlchemy==1.1.13
-tornado==6.3.3
+six==1.15.0
+SQLAlchemy==1.3.0
+sqlalchemy_mixins==1.5.3
+tornado==6.2.0
+bcrypt==3.2.0
+PyJWT==2.7.0
+bs4==0.0.1
+pyotp==2.6.0
+command-injection-tester==0.0.2
+sslyze==5.2.0
+google-cloud-storage==2.10.0
+google==3.0.0
+aiohttp==3.12.15
 

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,15 @@ class PostInstallCommand(install):
     """Post-installation for installation mode."""
 
     def run(self):
-        # Need because of a setuptools bug: https://github.com/pypa/setuptools/issues/456
-        self.do_egg_install()
+        # ``do_egg_install`` was removed in modern versions of setuptools but older
+        # releases still expect this compatibility shim.  Use it when available and
+        # otherwise fall back to the default ``install.run`` implementation so the
+        # package can be installed with contemporary tooling such as pip 25.
+        installer = getattr(self, "do_egg_install", None)
+        if callable(installer):
+            installer()
+        else:
+            super().run()
         print("Running post install")
         call(["/bin/bash", post_script])
 


### PR DESCRIPTION
## Summary
- update the Read the Docs configuration to build with Python 3.11 and rely on requirements files instead of installing the package itself
- align docs-specific dependency pins with the runtime requirements so Read the Docs can install them under Python 3.11
- add a Sphinx compatibility shim for the deprecated `force_decode` helper expected by sphinxcontrib.autohttp.tornado
- make the custom setuptools install hook fallback gracefully when `do_egg_install` is unavailable so pip can build wheels with modern tooling

## Testing
- `pip install -r requirements/docs.txt`
- `pip install -r docs/docs-requirements.txt`
- `pip install --no-deps .`
- `sphinx-build -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_6908e317c3408326a1db396d8d79cc4e