### PR TITLE
Refresh documentation theme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,9 @@
-How to write user docs
-======================
+# How to write user docs
 
-Make sure you have `sphinx` and `sphinx_rtd_theme` installed
+Install the documentation dependencies (including the site theme) with pip:
 
     ```
-    pip install sphinx sphinx_rtd_theme
+    pip install -r docs/docs-requirements.txt
     ```
 
 After editing the documentation, generate html using
@@ -15,4 +14,4 @@ After editing the documentation, generate html using
 
 Once you are satisfied with the changes, please push to the repo :)
 
-PS: It is strictly advised to fix all errors and warning before pushing
+PS: It is strictly advised to fix all errors and warnings before pushing.

--- a/docs/_static/owtf.css
+++ b/docs/_static/owtf.css
@@ -1,0 +1,19 @@
+/* Custom overrides for the OWTF documentation */
+
+:root {
+  --code-font-size: 0.95rem;
+}
+
+/* Provide a little extra room between navigation items */
+.sidebar-tree .reference {
+  padding-top: 0.1rem;
+  padding-bottom: 0.1rem;
+}
+
+/* Highlight inline code to improve readability on light and dark themes */
+span.sig-name,
+code.literal {
+  background-color: var(--color-background-secondary);
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.25rem;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 import os
-import sphinx_py3doc_enhanced_theme
 import sphinx.util
 
 # Compatibility shim: sphinxcontrib.autohttp.tornado still imports the deprecated
@@ -121,18 +120,19 @@ pygments_style = "friendly"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = "sphinx_py3doc_enhanced_theme"
-html_theme_path = [sphinx_py3doc_enhanced_theme.get_html_theme_path()]
+html_theme = "furo"
 
 html_theme_options = {
-    "githuburl": "https://github.com/ionelmc/sphinx-py3doc-enhanced-theme/",
-    "bodyfont": '"Lucida Grande",Arial,sans-serif',
-    "headfont": '"Lucida Grande",Arial,sans-serif',
-    "codefont": "monospace,sans-serif",
-    "linkcolor": "#0072AA",
-    "visitedlinkcolor": "#6363bb",
-    "extrastyling": False,
-    "appendcss": "div.body code.descclassname { display: none }",
+    "sidebar_hide_name": True,
+    "navigation_with_keys": True,
+    "light_css_variables": {
+        "color-brand-primary": "#f97316",
+        "color-brand-content": "#111827",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#fb923c",
+        "color-brand-content": "#f3f4f6",
+    },
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -162,7 +162,9 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static"]
+
+html_css_files = ["owtf.css"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,5 +1,5 @@
 sphinx
-sphinx_py3doc_enhanced_theme
+furo
 sphinxcontrib.httpdomain
 
 # Align the documentation build dependencies with the runtime pins from


### PR DESCRIPTION
## Summary
- switch the documentation site to the modern Furo Sphinx theme and configure OWTF brand colors
- add lightweight CSS refinements for navigation and inline code styling
- update documentation build instructions and requirements to align with the new theme

## Testing
- pip install -r docs/docs-requirements.txt
- make -C docs html

------
https://chatgpt.com/codex/tasks/task_e_69091b75a20c8326b25093c61397e244