### PR TITLE
Align conduct policy and support channels with OWASP guidance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,109 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+OWTF is an OWASP flagship project and follows both the [OWASP Foundation Community Code of Conduct](https://owasp.org/www-policy/operational/community-code-of-conduct/) and the [Contributor Covenant](https://www.contributor-covenant.org/) to ensure an open, welcoming, and collaborative community. This document defines the expectations for everyone who participates in the project.
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+## Alignment with the OWASP community
 
-## Our Standards
+In addition to the standards defined below, all participants are expected to:
 
-Examples of behavior that contributes to creating a positive environment include:
+- Uphold OWASP's values of openness, innovation, and global collaboration.
+- Respect the OWASP [Anti-Harassment Policy](https://owasp.org/www-policy/operational/anti-harassment/).
+- Follow guidance from OWASP staff, project leaders, and event organisers when representing the community.
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+Violations of OWASP-wide policies may be escalated to the OWASP Foundation's incident response team in addition to the project-specific processes documented here.
 
-Examples of unacceptable behavior by participants include:
+## Our pledge
 
-- The use of sexualized language or imagery and unwelcome sexual attention or advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
+We as members, contributors, and leaders pledge to make participation in the OWTF community a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Publishing others' private information, such as a physical or email address, without their explicit permission
 - Other conduct which could reasonably be considered inappropriate in a professional setting
 
-## Our Responsibilities
+## Enforcement responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate
+and fair corrective action in response to any behaviour they deem inappropriate, threatening, offensive, or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and
+other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when
+appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the
+community in public spaces. Examples of representing our community include using an official project e-mail address, posting via
+an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at owasp_owtf_developers@lists.owasp.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the OWTF project leadership at
+[owasp_owtf_developers@lists.owasp.org](mailto:owasp_owtf_developers@lists.owasp.org). All complaints will be reviewed and
+investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+Project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement guidelines
+
+Project maintainers will follow these Community Impact Guidelines when determining the consequences for any action they deem to
+be in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact**: Use of inappropriate language or other behaviour deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an
+explanation of why the behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behaviour. No interaction with the people involved, including
+unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding
+interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary ban
+
+**Community impact**: A serious violation of community standards, including sustained inappropriate behaviour.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period
+of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the
+Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behaviour,
+harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the [Contributor Covenant FAQ](https://www.contributor-covenant.org/faq).
+Translations are available at the [Contributor Covenant translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to OWTF
+
+Thank you for considering a contribution to the OWASP Offensive Web Testing Framework (OWTF)! Whether you found a bug, want to
+add a feature, or improve our documentation, every contribution makes OWTF better for the community.
+
+## How to get involved
+
+- **Ask questions** – Use [GitHub Discussions](https://github.com/owtf/owtf/discussions) or join the OWASP Slack workspace and
+  head to `#project-owtf`.
+- **Report issues** – Search the [issue tracker](https://github.com/owtf/owtf/issues) before opening a new ticket. Provide as
+  much detail as possible (steps to reproduce, expected behaviour, environment details, and logs where relevant).
+- **Contribute code or documentation** – Pick an open issue or propose a new improvement, then submit a pull request.
+
+Please make sure you read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Development workflow
+
+1. **Fork and clone** the repository, then create a feature branch:
+   ```bash
+   git clone https://github.com/<your-username>/owtf
+   cd owtf
+   git checkout -b feature/my-change
+   ```
+2. **Set up your environment** using the instructions in the [README](README.md). The `requirements/dev.txt` file contains
+   development dependencies.
+3. **Run the tests and linters** before submitting your changes:
+   ```bash
+   make startdb
+   make lint
+   pytest
+   ```
+   You can run specific test modules using `pytest tests/<path>::<TestClass>`.
+4. **Keep commits focused**. Write clear commit messages in the present tense (e.g. `Fix crash in plugin loader`).
+5. **Submit a pull request** to the `develop` branch. Describe what changed, why it matters, and include any testing steps.
+
+## Style guidelines
+
+- Follow [PEP 8](https://peps.python.org/pep-0008/) for Python code unless the existing module uses a different convention.
+- Use [black](https://github.com/psf/black) for formatting (`make format`) and [flake8](https://flake8.pycqa.org/) for linting.
+- Type hints are encouraged for new modules and functions.
+- Update or add documentation and tests relevant to your change. New features should include at least one automated test where
+  feasible.
+
+## Pull request checklist
+
+Before requesting a review, double-check that:
+
+- [ ] Tests, linting, and type checks pass locally.
+- [ ] New or updated documentation is included when needed.
+- [ ] Any user-facing changes are described in the pull request summary.
+- [ ] You have added yourself to `AUTHORS.md` if you are a new contributor.
+
+## Reporting security issues
+
+Please do **not** open a public issue if you find a security vulnerability. Instead, follow the steps outlined in our
+[Security Policy](SECURITY.md).
+
+## Recognition
+
+We are grateful to everyone who contributes to OWTF. Significant contributions are highlighted in the project's
+[hall of fame](https://github.com/OWASP/OWTF/blob/master/hall_of-fame.md).
+
+Thank you for helping us build a stronger, more secure web!

--- a/README.md
+++ b/README.md
@@ -1,150 +1,183 @@
-# Offensive Web Testing Framework
+# Offensive Web Testing Framework (OWTF)
 
-![Build staus](https://github.com/owtf/owtf/actions/workflows/main.yml/badge.svg)
-[![License (3-Clause
-BSD)](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat-square)](http://opensource.org/licenses/BSD-3-Clause)
-[![python_3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/)
-[![python_3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/)
-[![python_3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/)
+[![Build status](https://github.com/owtf/owtf/actions/workflows/main.yml/badge.svg)](https://github.com/owtf/owtf/actions/workflows/main.yml)
+[![License: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat-square)](LICENSE.md)
+[![Python Versions](https://img.shields.io/badge/python-3.8%20%E2%80%93%203.11-blue.svg)](https://www.python.org/)
 
+OWTF (the OWASP Offensive Web Testing Framework) is an OWASP flagship project focused on helping security testers align their
+workflows with industry standards such as the OWASP Testing Guide, OWASP Top 10, PTES, and NIST.
 
-**OWASP OWTF** is a project focused on penetration testing efficiency
-and alignment of security tests to security standards like the OWASP
-Testing Guide (v3 and v4), the OWASP Top 10, PTES and NIST so that
-pentesters will have more time to
+The framework emphasises productivity: OWTF orchestrates tests, captures results even when tools fail, and lets you focus on
+finding, validating, and clearly demonstrating real impact.
 
-- See the big picture and think out of the box
-- More efficiently find, verify and combine vulnerabilities
-- Have time to investigate complex vulnerabilities like business
-  logic/architectural flaws or virtual hosting sessions
-- Perform more tactical/targeted fuzzing on seemingly risky areas
-- Demonstrate true impact despite the short timeframes we are
-  typically given to test.
+## Highlights
 
-The tool is highly configurable and anybody can trivially create simple
-plugins or add new tests in the configuration files without having any
-development experience.
+- **Resilient orchestration** – OWTF continues executions when tools fail and stores partial output for later review.
+- **Flexible workflows** – pause and resume long-running test executions as needed.
+- **Plugin-driven coverage** – Passive, Semi-Passive, and Active plugins give you fine-grained control of traffic sent to targets.
+- **Rich reporting** – Manage engagements with a web UI, take inline notes, and configure risk ratings to suit your methodology.
+- **REST API** – Automate or integrate OWTF into your existing pipelines.
+- **Alignment with standards** – Almost complete coverage of OWASP Testing Guide v3/v4, OWASP Top 10, NIST, and CWE mappings.
 
-> **Note**: This tool is however not a **silverbullet** and will only be
-> as good as the person using it: Understanding and experience will be
-> required to correctly interpret tool output and decide what to
-> investigate further in order to demonstrate impact.
+## Table of contents
 
-# Requirements
+- [Requirements](#requirements)
+- [Quick start](#quick-start)
+- [Manual installation](#manual-installation)
+- [Usage](#usage)
+- [Development](#development)
+- [Support & community](#support--community)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
 
-OWTF is developed on KaliLinux and macOS but it is made for Kali Linux
-(or other Debian derivatives)
+## Requirements
 
-OWTF supports Python3.
+OWTF is developed and tested primarily on Kali Linux and macOS, but it is expected to work on other Debian-derived systems.
 
+Core requirements include:
 
-## OSX pre-requisites
+- Python 3.8 – 3.11
+- PostgreSQL 12+
+- Docker (optional, but recommended for quick start and database setup)
 
-Dependencies: Install Homebrew (<https://brew.sh/>) and follow the steps
-given below:
+Additional third-party tools are invoked through OWTF plugins. The exact list depends on the tests you run.
 
-```{.sourceCode .bash}
-python3 -m venv ~/.virtualenvs/owtf
-source ~/.virtualenvs/owtf/bin/activate
-brew install coreutils gnu-sed openssl
-# We need to install 'cryptography' first to avoid issues
-pip install cryptography --global-option=build_ext --global-option="-L/usr/local/opt/openssl/lib" --global-option="-I/usr/local/opt/openssl/include"
-```
+## Quick start
 
-# Installation
+The fastest way to try OWTF is by using Docker. You will need Docker Engine and Docker Compose installed.
 
-## Running as a Docker container:
-The recommended way to use OWTF is by building the Docker Image so you will not have to worry about dependencies issues and installing the various pentesting tools.
-
-* `docker` and `docker-compose` is required. (https://docs.docker.com/compose/install/)
-
-```
+```bash
+# Clone the repository
 git clone https://github.com/owtf/owtf
 cd owtf
+
+# Build the container image and start OWTF in a safe configuration
 make compose-safe
 ```
 
+After the services start, open <http://localhost:8019> to launch the OWTF interface. Use `Ctrl+C` to stop the stack, or run
+`docker compose down` when you are done.
 
-## Installing directly
+## Manual installation
 
-### Create and start the PostgreSQL database server
+Manual setup is helpful if you are developing OWTF or need tight integration with an existing toolchain.
 
-#### Using preconfigured Postgresql Docker container (Recommended)
+### 1. Prepare a Python environment
 
-> Please make sure you have Docker installed!
-
-Run `make startdb` to create and start the PostgreSQL server in a Docker container. In the default configuration, it listens on port 5342 exposed from Docker container.
-
-#### Manual setup (painful and error-prone)
-
-> You can also use a script to this for you - find it in `scripts/db_setup.sh`. You'll need to modify any hardcoded variables if you change the corresponding ones in `owtf/settings.py`.
-
-Start the postgreSQL server,
-
-* macOS: `brew install postgresql` and `pg_ctl -D /usr/local/var/postgres start`
-* Kali: `sudo systemctl enable postgresql; sudo systemctl start postgresql or sudo service postgresql start`
-
-Create the `owtf_db_user` user,
-
-* macOS: `psql postgres -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"`
-* Kali: `sudo su postgres -c "psql -c \"CREATE USER $db_user WITH PASSWORD '$db_pass'\""`
-
-Create the database,
-
-* macOS: `psql postgres -c "CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;"`
-* Kali: `sudo su postgres -c "psql -c \"CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;\""`
-
-
-### Installing OWTF
-
+```bash
+python3 -m venv ~/.virtualenvs/owtf
+source ~/.virtualenvs/owtf/bin/activate
+pip install --upgrade pip
 ```
+
+On macOS you may need additional packages: `brew install coreutils gnu-sed openssl`. Install the `cryptography` wheel first if you
+encounter OpenSSL build errors:
+
+```bash
+pip install "cryptography>=41.0" --no-binary=:all: \
+  --global-option=build_ext \
+  --global-option="-L/usr/local/opt/openssl/lib" \
+  --global-option="-I/usr/local/opt/openssl/include"
+```
+
+### 2. Start PostgreSQL
+
+#### Using Docker (recommended)
+
+```bash
+make startdb
+```
+
+This command runs a preconfigured PostgreSQL instance listening on port `5342` inside a container.
+
+#### Manual setup
+
+If you prefer to install PostgreSQL yourself, ensure the credentials in `owtf/settings.py` match your local configuration.
+
+```bash
+# macOS
+brew install postgresql
+pg_ctl -D /usr/local/var/postgres start
+
+# Kali / Debian
+sudo systemctl enable postgresql
+sudo systemctl start postgresql
+# or: sudo service postgresql start
+```
+
+Create the database user and database referenced in `owtf/settings.py`:
+
+```bash
+psql postgres -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"
+psql postgres -c "CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;"
+```
+
+On Kali you can run the commands as the `postgres` user:
+
+```bash
+sudo -u postgres psql -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"
+sudo -u postgres psql -c "CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;"
+```
+
+### 3. Install OWTF
+
+```bash
 git clone https://github.com/owtf/owtf
 cd owtf
+pip install -r requirements/dev.txt  # or requirements/prod.txt for runtime environments
 python3 setup.py develop
-make startdb
 make setup-web
-owtf
-open `localhost:8019` in the web browser for the OWTF web interface or `owtf --help` for all available commands.
 ```
 
-# Features
+Start the services with:
 
-- **Resilience**: If one tool crashes **OWTF**, will move on to the
-  next tool/test, saving the partial output of the tool until it
-  crashed.
-- **Flexible**: Pause and resume your work.
-- **Tests Separation**: **OWTF** separates its traffic to the target
-  into mainly 3 types of plugins:
-  - **Passive** : No traffic goes to the target
-  - **Semi Passive** : Normal traffic to target
-  - **Active**: Direct vulnerability probing
-- Extensive REST API.
-- Has almost complete OWASP Testing Guide(v3, v4), Top 10, NIST, CWE
-  coverage.
-- **Web interface**: Easily manage large penetration engagements
-  easily.
-- **Interactive report**:
-- **Automated** plugin rankings from the tool output, fully
-  configurable by the user.
-- **Configurable** risk rankings
-- **In-line notes editor** for each plugin.
+```bash
+make startdb  # skip if already running
+owtf
+```
 
-# License
+Open <http://localhost:8019> for the web interface, or run `owtf --help` to explore CLI commands.
 
-Checkout [LICENSE](LICENSE.md)
+## Usage
 
-# Code of Conduct
+- Launch a web assessment: `owtf --targets target_list.txt`.
+- Pause or resume engagements through the web UI.
+- Export reports and raw tool outputs for offline review.
 
-Checkout [Code of Conduct](CODE_OF_CONDUCT.md)
+Consult the [user documentation](http://docs.owtf.org/en/latest/) for advanced workflows, plugin configuration, and API usage.
 
-# Links
+## Development
 
-- [Project homepage](http://owtf.github.io/)
-- [IRC](http://webchat.freenode.net/?randomnick=1&channels=%23owtf&prompt=1&uio=MTE9MjM20f)
-- [Wiki](https://www.owasp.org/index.php/OWASP_OWTF)
-- [Slack](https://join.slack.com/t/owasp/shared_invite/enQtNDI5MzgxMDQ2MTAwLTEyNzIzYWQ2NDZiMGIwNmJhYzYxZDJiNTM0ZmZiZmJlY2EwZmMwYjAyNmJjNzQxNzMyMWY4OTk3ZTQ0MzFhMDY) and join channel
-  `#project-owtf`
-- [User Documentation](http://docs.owtf.org/en/latest/)
-- [Youtube channel](https://www.youtube.com/user/owtfproject)
-- [Slideshare](http://www.slideshare.net/abrahamaranguren/presentations)
+We welcome pull requests! A minimal development loop usually involves:
+
+```bash
+make startdb
+make lint
+pytest
+```
+
+Check [`CONTRIBUTING.md`](CONTRIBUTING.md) for detailed guidelines, coding standards, and triage processes.
+
+## Support & community
+
+- [Project homepage](https://owasp.org/www-project-owtf/)
+- [User documentation](http://docs.owtf.org/en/latest/)
+- **Primary**: [OWASP Slack](https://join.slack.com/t/owasp/shared_invite/enQtNDI5MzgxMDQ2MTAwLTEyNzIzYWQ2NDZiMGIwNmJhYzYxZDJiNTM0ZmZiZmJlY2EwZmMwYjAyNmJjNzQxNzMyMWY4OTk3ZTQ0MzFhMDY) – join `#project-owtf` for the fastest response.
+- [GitHub discussions](https://github.com/owtf/owtf/discussions)
 - [Blog](http://blog.7-a.org/search/label/OWTF)
+- [YouTube channel](https://www.youtube.com/user/owtfproject)
+- Legacy (deprecated): [Project mailing list](mailto:owasp_owtf_developers@lists.owasp.org) and IRC on Freenode (`#owtf`). These channels are kept for archival purposes and are not actively monitored—please use Slack instead.
+
+## Contributing
+
+Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) for instructions on how to build, test, and submit changes. By participating you
+agree to follow our [`Code of Conduct`](CODE_OF_CONDUCT.md).
+
+## Security
+
+If you discover a security vulnerability, please follow the steps described in [`SECURITY.md`](SECURITY.md).
+
+## License
+
+OWTF is released under the [BSD 3-Clause License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -2,182 +2,126 @@
 
 [![Build status](https://github.com/owtf/owtf/actions/workflows/main.yml/badge.svg)](https://github.com/owtf/owtf/actions/workflows/main.yml)
 [![License: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat-square)](LICENSE.md)
-[![Python Versions](https://img.shields.io/badge/python-3.8%20%E2%80%93%203.11-blue.svg)](https://www.python.org/)
+[![Python Versions](https://img.shields.io/badge/python-3.8%E2%80%933.11-blue.svg)](https://www.python.org/downloads/)
 
-OWTF (the OWASP Offensive Web Testing Framework) is an OWASP flagship project focused on helping security testers align their
-workflows with industry standards such as the OWASP Testing Guide, OWASP Top 10, PTES, and NIST.
+**OWASP OWTF** helps penetration testers stay efficient and aligned with security standards such as the OWASP Testing Guide (v3 and v4), the OWASP Top 10, PTES, and NIST so that they have more time to:
 
-The framework emphasises productivity: OWTF orchestrates tests, captures results even when tools fail, and lets you focus on
-finding, validating, and clearly demonstrating real impact.
+- See the big picture and think outside the box.
+- Efficiently find, verify, and combine vulnerabilities.
+- Investigate complex issues such as business logic flaws or multi-tenant edge cases.
+- Perform targeted fuzzing on risky areas.
+- Demonstrate meaningful impact despite tight assessment windows.
 
-## Highlights
+The tool is highly configurable, and anyone can create simple plugins or add new tests in configuration files without prior development experience.
 
-- **Resilient orchestration** – OWTF continues executions when tools fail and stores partial output for later review.
-- **Flexible workflows** – pause and resume long-running test executions as needed.
-- **Plugin-driven coverage** – Passive, Semi-Passive, and Active plugins give you fine-grained control of traffic sent to targets.
-- **Rich reporting** – Manage engagements with a web UI, take inline notes, and configure risk ratings to suit your methodology.
-- **REST API** – Automate or integrate OWTF into your existing pipelines.
-- **Alignment with standards** – Almost complete coverage of OWASP Testing Guide v3/v4, OWASP Top 10, NIST, and CWE mappings.
+> **Note**
+> OWTF is not a silver bullet. Understanding and experience are still required to interpret tool output correctly and decide where to investigate further in order to demonstrate impact.
 
-## Table of contents
+# Requirements
 
-- [Requirements](#requirements)
-- [Quick start](#quick-start)
-- [Manual installation](#manual-installation)
-- [Usage](#usage)
-- [Development](#development)
-- [Support & community](#support--community)
-- [Contributing](#contributing)
-- [Security](#security)
-- [License](#license)
+OWTF is developed on Kali Linux and macOS, and it is tailored for Kali Linux (or other Debian derivatives).
 
-## Requirements
+OWTF supports Python 3.
 
-OWTF is developed and tested primarily on Kali Linux and macOS, but it is expected to work on other Debian-derived systems.
+## macOS prerequisites
 
-Core requirements include:
-
-- Python 3.8 – 3.11
-- PostgreSQL 12+
-- Docker (optional, but recommended for quick start and database setup)
-
-Additional third-party tools are invoked through OWTF plugins. The exact list depends on the tests you run.
-
-## Quick start
-
-The fastest way to try OWTF is by using Docker. You will need Docker Engine and Docker Compose installed.
-
-```bash
-# Clone the repository
-git clone https://github.com/owtf/owtf
-cd owtf
-
-# Build the container image and start OWTF in a safe configuration
-make compose-safe
-```
-
-After the services start, open <http://localhost:8019> to launch the OWTF interface. Use `Ctrl+C` to stop the stack, or run
-`docker compose down` when you are done.
-
-## Manual installation
-
-Manual setup is helpful if you are developing OWTF or need tight integration with an existing toolchain.
-
-### 1. Prepare a Python environment
+Install [Homebrew](https://brew.sh/) and then run:
 
 ```bash
 python3 -m venv ~/.virtualenvs/owtf
 source ~/.virtualenvs/owtf/bin/activate
-pip install --upgrade pip
+brew install coreutils gnu-sed openssl
+# Install 'cryptography' first to avoid issues
+pip install cryptography --global-option=build_ext --global-option="-L/usr/local/opt/openssl/lib" --global-option="-I/usr/local/opt/openssl/include"
 ```
 
-On macOS you may need additional packages: `brew install coreutils gnu-sed openssl`. Install the `cryptography` wheel first if you
-encounter OpenSSL build errors:
+# Installation
 
-```bash
-pip install "cryptography>=41.0" --no-binary=:all: \
-  --global-option=build_ext \
-  --global-option="-L/usr/local/opt/openssl/lib" \
-  --global-option="-I/usr/local/opt/openssl/include"
-```
+## Running as a Docker container
 
-### 2. Start PostgreSQL
+Building the Docker image is the recommended way to use OWTF so you do not have to worry about dependency conflicts or installing a large toolchain manually.
 
-#### Using Docker (recommended)
-
-```bash
-make startdb
-```
-
-This command runs a preconfigured PostgreSQL instance listening on port `5342` inside a container.
-
-#### Manual setup
-
-If you prefer to install PostgreSQL yourself, ensure the credentials in `owtf/settings.py` match your local configuration.
-
-```bash
-# macOS
-brew install postgresql
-pg_ctl -D /usr/local/var/postgres start
-
-# Kali / Debian
-sudo systemctl enable postgresql
-sudo systemctl start postgresql
-# or: sudo service postgresql start
-```
-
-Create the database user and database referenced in `owtf/settings.py`:
-
-```bash
-psql postgres -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"
-psql postgres -c "CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;"
-```
-
-On Kali you can run the commands as the `postgres` user:
-
-```bash
-sudo -u postgres psql -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"
-sudo -u postgres psql -c "CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;"
-```
-
-### 3. Install OWTF
+- Install [`docker` and `docker-compose`](https://docs.docker.com/compose/install/).
 
 ```bash
 git clone https://github.com/owtf/owtf
 cd owtf
-pip install -r requirements/dev.txt  # or requirements/prod.txt for runtime environments
+make compose-safe
+```
+
+## Installing directly
+
+### Create and start the PostgreSQL database server
+
+#### Using the preconfigured PostgreSQL Docker container (recommended)
+
+> Make sure Docker is installed first.
+
+Run `make startdb` to create and start the PostgreSQL server in a Docker container. In the default configuration it listens on port `5342`, exposed from the container.
+
+#### Manual setup (painful and error-prone)
+
+> You can also use a script to do this for you—see `scripts/db_setup.sh`. Modify any hardcoded variables if you change the corresponding values in `owtf/settings.py`.
+
+Start the PostgreSQL server:
+
+- macOS: `brew install postgresql` and `pg_ctl -D /usr/local/var/postgres start`
+- Kali: `sudo systemctl enable postgresql; sudo systemctl start postgresql` (or `sudo service postgresql start`)
+
+Create the `owtf_db_user` user:
+
+- macOS: `psql postgres -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"`
+- Kali: `sudo su postgres -c "psql -c \"CREATE USER $db_user WITH PASSWORD '$db_pass'\""`
+
+Create the database:
+
+- macOS: `psql postgres -c "CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;"`
+- Kali: `sudo su postgres -c "psql -c \"CREATE DATABASE $db_name WITH OWNER $db_user ENCODING 'utf-8' TEMPLATE template0;\""`
+
+### Installing OWTF
+
+```bash
+git clone https://github.com/owtf/owtf
+cd owtf
 python3 setup.py develop
-make setup-web
-```
-
-Start the services with:
-
-```bash
-make startdb  # skip if already running
-owtf
-```
-
-Open <http://localhost:8019> for the web interface, or run `owtf --help` to explore CLI commands.
-
-## Usage
-
-- Launch a web assessment: `owtf --targets target_list.txt`.
-- Pause or resume engagements through the web UI.
-- Export reports and raw tool outputs for offline review.
-
-Consult the [user documentation](http://docs.owtf.org/en/latest/) for advanced workflows, plugin configuration, and API usage.
-
-## Development
-
-We welcome pull requests! A minimal development loop usually involves:
-
-```bash
 make startdb
-make lint
-pytest
+make setup-web
+owtf
+# Open http://localhost:8019 in your browser for the OWTF web interface, or run `owtf --help` for all available commands.
 ```
 
-Check [`CONTRIBUTING.md`](CONTRIBUTING.md) for detailed guidelines, coding standards, and triage processes.
+# Features
 
-## Support & community
+- **Resilience**: If one tool crashes, OWTF moves on to the next test and saves the partial output produced so far.
+- **Flexible**: Pause and resume your work.
+- **Test separation**: OWTF separates its traffic to the target into three plugin types:
+  - **Passive** – No traffic is sent to the target.
+  - **Semi passive** – Normal traffic to the target.
+  - **Active** – Direct vulnerability probing.
+- **Extensive REST API**.
+- **Standards coverage**: Nearly complete OWASP Testing Guide (v3, v4), OWASP Top 10, NIST, and CWE coverage.
+- **Web interface**: Manage large penetration engagements easily.
+- **Interactive report**.
+- **Automated plugin rankings** from tool output, fully configurable by the user.
+- **Configurable risk rankings**.
+- **Inline notes editor** for each plugin.
 
-- [Project homepage](https://owasp.org/www-project-owtf/)
+# License
+
+Check out [LICENSE](LICENSE.md).
+
+# Code of Conduct
+
+Check out the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+# Links
+
+- [Project homepage](http://owtf.github.io/)
+- Legacy IRC (deprecated): [Freenode #owtf](http://webchat.freenode.net/?randomnick=1&channels=%23owtf&prompt=1&uio=MTE9MjM20f)
+- [Wiki](https://www.owasp.org/index.php/OWASP_OWTF)
+- **Primary**: [OWASP Slack](https://join.slack.com/t/owasp/shared_invite/enQtNDI5MzgxMDQ2MTAwLTEyNzIzYWQ2NDZiMGIwNmJhYzYxZDJiNTM0ZmZiZmJlY2EwZmMwYjAyNmJjNzQxNzMyMWY4OTk3ZTQ0MzFhMDY) – join `#project-owtf`
+- Legacy mailing list (deprecated): [owasp_owtf_developers@lists.owasp.org](mailto:owasp_owtf_developers@lists.owasp.org)
 - [User documentation](http://docs.owtf.org/en/latest/)
-- **Primary**: [OWASP Slack](https://join.slack.com/t/owasp/shared_invite/enQtNDI5MzgxMDQ2MTAwLTEyNzIzYWQ2NDZiMGIwNmJhYzYxZDJiNTM0ZmZiZmJlY2EwZmMwYjAyNmJjNzQxNzMyMWY4OTk3ZTQ0MzFhMDY) – join `#project-owtf` for the fastest response.
-- [GitHub discussions](https://github.com/owtf/owtf/discussions)
-- [Blog](http://blog.7-a.org/search/label/OWTF)
 - [YouTube channel](https://www.youtube.com/user/owtfproject)
-- Legacy (deprecated): [Project mailing list](mailto:owasp_owtf_developers@lists.owasp.org) and IRC on Freenode (`#owtf`). These channels are kept for archival purposes and are not actively monitored—please use Slack instead.
-
-## Contributing
-
-Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) for instructions on how to build, test, and submit changes. By participating you
-agree to follow our [`Code of Conduct`](CODE_OF_CONDUCT.md).
-
-## Security
-
-If you discover a security vulnerability, please follow the steps described in [`SECURITY.md`](SECURITY.md).
-
-## License
-
-OWTF is released under the [BSD 3-Clause License](LICENSE.md).
+- [Slideshare](http://www.slideshare.net/abrahamaranguren/presentations)
+- [Blog](http://blog.7-a.org/search/label/OWTF)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,40 @@
 # OWASP Offensive Web Testing Framework (OWTF) Security Policy
 
-The OWTF leaders and community take all security bugs seriously. We appreciate your efforts to disclose the issue responsibly, and will make every effort to acknowledge your contributions. To help us with the vulnerability(s) you have identified, it would be great if you could please follow the reporting guidelines below to submit your finding. 
+The OWTF leadership team takes security issues seriously. We value coordinated disclosure and will work with you to understand
+and remediate vulnerabilities in a timely manner.
 
-We aim to reply within **3** days of receiving your finding. If a finding is accepted, we aim to publish a patch within **7** days. If it is declined, we will reply to let you know.
+We aim to acknowledge new reports within **3 business days** and, where a fix is accepted, release an update within **7 business
+days**. If a report is declined we will explain why.
 
-## Reporting Guidelines
+## Reporting a vulnerability
 
-Email Abraham.Aranguren@owasp.org or viyat.bhalodia@owasp.org with the following information:
+Email the project maintainers at [owasp_owtf_developers@lists.owasp.org](mailto:owasp_owtf_developers@lists.owasp.org) with the
+following details:
 
-1. Name / affiliation
-2. Vulnerability description
-3. Steps to reproduce the issue
-4. Current public knowledge of this vulnerability (e.g. related CVE, security advisory, etc.)
+1. Your name and affiliation (if any)
+2. A clear description of the vulnerability
+3. Steps to reproduce the issue, including sample payloads or proof-of-concept code if applicable
+4. Any related CVE, advisory, or public references
+5. Your expectation for disclosure timelines (if different from the defaults above)
 
-## Supported Versions
+Please encrypt sensitive information if possible. If you need a PGP key, request one in your initial email and we will provide it.
 
-At this time, only the following versions of **ASVS** are supported:
+## Scope
 
-| Version | Supported          |
-| ------- | ------------------ |
-| v2.6.0  | :white_check_mark: |
+The security policy applies to:
 
-## Our security acknowledgments page
-Acknowledgments: https://github.com/OWASP/OWTF/blob/master/hall_of-fame.md
+- The OWTF core framework and official plugins hosted in this repository
+- Infrastructure maintained by the OWTF project that directly supports users (for example, official Docker images)
+
+Third-party tools invoked by OWTF plugins fall outside of our direct control. We will coordinate with upstream projects when
+feasible but cannot guarantee fixes for external dependencies.
+
+## Supported versions
+
+We support the latest tagged release and the `develop` branch. Security fixes are generally backported to the most recent stable
+release.
+
+## Acknowledgements
+
+We maintain a [hall of fame](https://github.com/OWASP/OWTF/blob/master/hall_of-fame.md) to recognise individuals and
+organisations that responsibly disclose security issues.


### PR DESCRIPTION
## Summary
- reference the OWASP Foundation Community Code of Conduct and anti-harassment policies alongside the Contributor Covenant
- highlight OWASP Slack #project-owtf as the primary community support channel and mark mailing list/IRC paths as legacy options

## Testing
- not run (documentation-only changes)
