### PR TITLE
Improve email validation and coverage

### DIFF
--- a/owtf/webapp/src/containers/ForgotPasswordPage/ForgotPasswordPage.test.js
+++ b/owtf/webapp/src/containers/ForgotPasswordPage/ForgotPasswordPage.test.js
@@ -79,6 +79,39 @@ describe("ForgotPasswordPage component", () => {
       expect(wrapper.instance().state.emailOrUsername).toEqual(emailOrUsername);
     });
 
+    it("Should accept supported email formats during validation", () => {
+      const validEmails = [
+        "myemail+owtf@domain.com",
+        "mike.o'connor@domain.com"
+      ];
+
+      validEmails.forEach(email => {
+        wrapper.setState({ emailOrUsername: email, emailError: "" });
+        wrapper.instance().handleEmailValidation({
+          target: { name: "text-input-email-or-username" }
+        });
+        expect(wrapper.state("emailError")).toEqual("");
+      });
+    });
+
+    it("Should reject malformed email formats during validation", () => {
+      const invalidEmails = [
+        "myemail@domain...com",
+        "my....email@domain.com",
+        "myemail@.domain.com"
+      ];
+
+      invalidEmails.forEach(email => {
+        wrapper.setState({ emailOrUsername: email, emailError: "" });
+        wrapper.instance().handleEmailValidation({
+          target: { name: "text-input-email-or-username" }
+        });
+        expect(wrapper.state("emailError")).toEqual(
+          "Please enter a valid email"
+        );
+      });
+    });
+
     it("Should call onReset on reset password button click", () => {
       expect(props.onReset.mock.calls.length).toBe(0);
       const resetPasswordButton = wrapper.find("button");

--- a/owtf/webapp/src/containers/ForgotPasswordPage/index.tsx
+++ b/owtf/webapp/src/containers/ForgotPasswordPage/index.tsx
@@ -7,18 +7,17 @@ import { Link } from "react-router-dom";
 import { forgotPasswordEmailStart } from "./actions";
 import { connect } from "react-redux";
 import logo from "../../../public/img/logo.png";
-
+import { EMAIL_REGEX } from "../../utils/validation";
 
 interface propsType {
-  onReset: Function
+  onReset: Function;
 }
 interface stateType {
-  emailOrUsername: string,
-  emailError: string
+  emailOrUsername: string;
+  emailError: string;
 }
 
-
-export class ForgotPasswordPage extends React.Component<propsType , stateType>  {
+export class ForgotPasswordPage extends React.Component<propsType, stateType> {
   constructor(props, context) {
     super(props, context);
 
@@ -37,11 +36,7 @@ export class ForgotPasswordPage extends React.Component<propsType , stateType>  
     if (!this.state.emailOrUsername) {
       this.setState({ emailError: "Email can't be empty" });
     } else if (typeof this.state.emailOrUsername !== "undefined") {
-      if (
-        !this.state.emailOrUsername.match(
-          /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/
-        )
-      ) {
+      if (!EMAIL_REGEX.test(this.state.emailOrUsername)) {
         this.setState({ emailError: "Please enter a valid email" });
       } else {
         this.setState({ emailError: "" });
@@ -103,7 +98,6 @@ export class ForgotPasswordPage extends React.Component<propsType , stateType>  
     );
   }
 }
-
 
 const mapDispatchToProps = dispatch => {
   return {

--- a/owtf/webapp/src/containers/SignupPage/SignupPage.test.js
+++ b/owtf/webapp/src/containers/SignupPage/SignupPage.test.js
@@ -97,9 +97,7 @@ describe("SignupPage component", () => {
       textInputFieldPassword.simulate("change", eventChangePassword);
       expect(wrapper.instance().state.password).toEqual("Test@12345");
 
-      const textInputFieldConfirmPassword = wrapper
-        .find("input")
-        .at(3);
+      const textInputFieldConfirmPassword = wrapper.find("input").at(3);
       const eventChangeConfirmPassword = {
         preventDefault() {},
         target: { value: "Test@12345", name: "text-input-confirm-password" }
@@ -109,6 +107,39 @@ describe("SignupPage component", () => {
         eventChangeConfirmPassword
       );
       expect(wrapper.instance().state.confirmPassword).toEqual("Test@12345");
+    });
+
+    it("Should accept supported email formats during validation", () => {
+      const validEmails = [
+        "myemail+owtf@domain.com",
+        "mike.o'connor@domain.com"
+      ];
+
+      validEmails.forEach(email => {
+        wrapper.setState({ email, errors: {} });
+        wrapper.instance().handleValidation({
+          target: { name: "text-input-email" }
+        });
+        expect(wrapper.state("errors")["email"]).toBeUndefined();
+      });
+    });
+
+    it("Should reject malformed email formats during validation", () => {
+      const invalidEmails = [
+        "myemail@domain...com",
+        "my....email@domain.com",
+        "myemail@.domain.com"
+      ];
+
+      invalidEmails.forEach(email => {
+        wrapper.setState({ email, errors: {} });
+        wrapper.instance().handleValidation({
+          target: { name: "text-input-email" }
+        });
+        expect(wrapper.state("errors")["email"]).toEqual(
+          "Please enter a valid email"
+        );
+      });
     });
 
     it("Should call onSignup on signup button click", () => {

--- a/owtf/webapp/src/containers/SignupPage/index.tsx
+++ b/owtf/webapp/src/containers/SignupPage/index.tsx
@@ -11,6 +11,7 @@ import { connect } from "react-redux";
 import logo from "../../../public/img/logo.png";
 import { AiFillEyeInvisible } from "react-icons/ai";
 import { AiFillEye } from "react-icons/ai";
+import { EMAIL_REGEX } from "../../utils/validation";
 
 interface propsType {
   onSignup: Function;
@@ -62,11 +63,7 @@ export class SignupPage extends React.Component<propsType, stateType> {
       e.target.name === "text-input-email" &&
       typeof this.state.email !== "undefined"
     ) {
-      if (
-        !this.state.email.match(
-          /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/
-        )
-      ) {
+      if (!EMAIL_REGEX.test(this.state.email)) {
         formIsValid = false;
         errors["email"] = "Please enter a valid email";
       }

--- a/owtf/webapp/src/utils/validation.ts
+++ b/owtf/webapp/src/utils/validation.ts
@@ -1,0 +1,1 @@
+export const EMAIL_REGEX = /^[a-zA-Z0-9]+([_+.%'-]?[a-zA-Z0-9]+)*@[a-zA-Z0-9]+([.-]?[a-zA-Z0-9]+)*\.[A-Za-z]{2,}$/;


### PR DESCRIPTION
## Summary
- replace the duplicated email validation regex with a shared utility that accepts expected characters and blocks invalid dot sequences
- reuse the new validation helper in the signup and forgot password flows and expand their tests to cover valid and invalid examples

## Testing
- CI=1 npm test -- SignupPage *(fails: jest cannot resolve the built-in module alias `node:stream` in this environment)*