### PR TITLE
Fix Docker build issues: pip cache purge and SSL certificates

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -86,9 +86,16 @@ COPY --chown=owtf:owtf setup.py setup.cfg MANIFEST.in README.md ${HOME}/
 # Install OWTF using the recommended method (setup.py)
 RUN cd ${HOME} && \
     python setup.py install
+# Generate SSL certificates for proxy
+RUN mkdir -p ${HOME}/.owtf/proxy/certs && \
+    openssl req -new -x509 -keyout ${HOME}/.owtf/proxy/certs/ca.key \
+    -out ${HOME}/.owtf/proxy/certs/ca.crt -days 3650 -nodes \
+    -subj "/C=US/ST=State/L=City/O=OWTF/CN=OWTF-CA" && \
+    echo "owtf" > ${HOME}/.owtf/proxy/certs/ca_pass.txt && \
+    chown -R owtf:owtf ${HOME}/.owtf
 
 # Reduce cache footprint from pip to keep final image size smaller
-RUN pip cache purge && rm -rf ${HOME}/.cache
+RUN pip cache purge || true && rm -rf ${HOME}/.cache || true
 
 # Stage 3: Runtime image
 FROM base AS final_install
@@ -112,6 +119,7 @@ COPY --from=owtf_setup /home/owtf/setup.py ${HOME}/setup.py
 COPY --from=owtf_setup /home/owtf/setup.cfg ${HOME}/setup.cfg
 COPY --from=owtf_setup /home/owtf/MANIFEST.in ${HOME}/MANIFEST.in
 COPY --from=owtf_setup /home/owtf/README.md ${HOME}/README.md
+COPY --from=owtf_setup /home/owtf/.owtf ${HOME}/.owtf
 
 RUN chown -R owtf:owtf ${HOME}
 


### PR DESCRIPTION
Fixes #1331

<!--- Provide a general, concise summary of your changes in the Title above -->

## Description
This PR fixes two critical issues preventing OWTF Docker builds from working on macOS and potentially other platforms.

## Changes Made

### 1. Made pip cache purge non-critical (Line 97)
Added `|| true` to prevent build failure when pip cache cannot be purged due to permission issues.

**Before:**
```dockerfile
RUN pip cache purge && rm -rf ${HOME}/.cache
```

**After:**
```dockerfile
RUN pip cache purge || true && rm -rf ${HOME}/.cache || true
```

### 2. Generate SSL certificates during Docker build (Lines 90-95)
Added OpenSSL commands to generate required proxy certificates during the build process.
```dockerfile
# Generate SSL certificates for proxy
RUN mkdir -p ${HOME}/.owtf/proxy/certs && \
    openssl req -new -x509 -keyout ${HOME}/.owtf/proxy/certs/ca.key \
    -out ${HOME}/.owtf/proxy/certs/ca.crt -days 3650 -nodes \
    -subj "/C=US/ST=State/L=City/O=OWTF/CN=OWTF-CA" && \
    echo "owtf" > ${HOME}/.owtf/proxy/certs/ca_pass.txt && \
    chown -R owtf:owtf ${HOME}/.owtf
```

### 3. Ensured .owtf directory is copied to final stage (Line 119)
Verified that the `.owtf` directory (containing SSL certs) is copied from `owtf_setup` to `final_install` stage.

## Testing
- ✅ Docker build completes successfully on macOS (Apple Silicon)
- ✅ Backend container starts without SSL certificate errors
- ✅ Proxy service initializes correctly
- ✅ Web interface accessible at http://localhost:8019

## Related Issues
Fixes #1331

## Checklist
- [x] Code follows project style guidelines
- [x] Tested in Docker environment on macOS
- [x] Related issue referenced
- [x] Changes are minimal and focused on the specific problem
- [x] No breaking changes to existing functionality

