### PR TITLE
Fix Docker build on macOS and add ARM64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ cd owtf
 make compose-safe
 ```
 
+## macOS (Apple Silicon / ARM64) Docker Setup
+
+OWTF supports Apple Silicon (M1/M2/M3) via multi-architecture Docker images.
+
+### Requirements
+- Docker Desktop v4.0 or newer
+
+### Steps
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/arm64
+docker compose build
+docker compose up
+```
+
 ## Installing directly
 
 ### Create and start the PostgreSQL database server

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,5 +1,6 @@
 # Stage 1: Base
-FROM kalilinux/kali-rolling AS base
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM kalilinux/kali-rolling
 
 LABEL maintainer="Viyat Bhalodia <viyat.bhalodia@owasp.org>"
 

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,15 +1,24 @@
 # Stage 1: Build the React app
-FROM node:20 AS builder
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM node:20 AS builder
+
 WORKDIR /owtf-webapp
+
 COPY ./owtf/webapp/package.json ./owtf/webapp/yarn.lock ./
-RUN yarn install --silent
+
+# Force native build for ARM64
+RUN rm -rf node_modules yarn.lock && yarn install --silent --build-from-source
+
 COPY ./owtf/webapp .
 RUN yarn build
-# # Stage 2: Serve the built React app with Nginx
-FROM nginx:alpine
+
+# Stage 2: Serve the built React app with Nginx
+FROM --platform=$TARGETPLATFORM nginx:alpine
+
 COPY ./owtf/webapp/owtf.conf /etc/nginx/conf.d/default.conf
+
 # Copy the built React app to Nginx's web server directory
 COPY --from=builder /owtf-webapp/build /usr/share/nginx/html
+
 EXPOSE 8019
 CMD ["nginx", "-g", "daemon off;"]
-# Start Nginx when the container runs

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,3 +12,23 @@ services:
       - POSTGRES_USER=owtf_db_user
       - POSTGRES_PASSWORD=jgZKW33Q+HZk8rqylZxaPg1lbuNGHJhgzsq3gBKV32g=
       - POSTGRES_DB=owtf_db
+
+  backend:
+    platform: linux/arm64
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.backend
+    depends_on:
+      - db
+    ports:
+      - 8008:8008
+
+  frontend:
+    platform: linux/arm64
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.frontend
+    depends_on:
+      - backend
+    ports:
+      - 8019:8019

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   db:
+    platform: linux/arm64
     container_name: owtf_db
     image: postgres:alpine
     ports:


### PR DESCRIPTION
Fixes #1340

This PR:
- Makes backend and frontend Dockerfiles platform-aware
- Fixes frontend build issues on ARM64
- Adds platform configuration to docker-compose services
- Updates documentation for Apple Silicon users

Tested with Docker Buildx and docker compose on ARM64.
