### PR TITLE
Update User-Agent to Firefox 134.0

### DIFF
--- a/owtf/settings.py
+++ b/owtf/settings.py
@@ -180,7 +180,7 @@ REPLACEMENT_DELIMITER = "@@@"
 REPLACEMENT_DELIMITER_LENGTH = len(REPLACEMENT_DELIMITER)
 CONFIG_TYPES = ["string", "other"]
 
-USER_AGENT = "Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/15.0"
+USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:134.0) Gecko/20100101 Firefox/134.0"
 PROXY_CHECK_URL = "http://www.google.ie"
 
 # Fallback


### PR DESCRIPTION
Update User-Agent to Firefox 134.0

<!--- Provide a general, concise summary of your changes in the Title above -->
Updates the default User-Agent string which was still set to Firefox 15.0 (circa 2012).

## Description
<!--- Describe your changes in detail -->
Changed `USER_AGENT` in [settings.py](cci:7://file:///d:/gsoc%20org/owtf/owtf/owtf/settings.py:0:0-0:0) to use a modern Firefox version (134.0) on Linux x86_64. The previous value was flagging traffic as suspicious/bot-like on most WAFs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1353

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Running scans with a 14-year-old browser string is basically asking to be blocked. Updated to blend in better.

## Reviewers
<!--- @mentions of the person/people responsible for reviewing proposed changes. -->
@viyatb

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified the new string appears in outbound requests. It's a string replacement, pretty low risk.

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
