### PR TITLE
Align runtime baseline and docker compose usage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
-          "version": "3.9"}
+      "version": "3.11"
+    }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,11 @@ docker-run:
 ### Options to allow docker to have permissive network capabilities, allowing it to run tools such as nmap
 compose-safe:
 	@echo "--> Running the Docker Compose setup with network capabilties for container"
-	docker-compose -f docker/docker-compose.dev.yml up --build
+	docker compose -f docker/docker-compose.dev.yml up --build
 
 compose-unsafe:
 	@echo "--> Running the Docker Compose setup without network capabilties for container"
-	docker-compose -f docker/docker-compose.dev.unsafe.yml up --build
+	docker compose -f docker/docker-compose.dev.unsafe.yml up --build
 
 ### DEBIAN PACKAGING
 
@@ -200,7 +200,7 @@ build:
 	$(PYTHON) setup.py sdist bdist_wheel
 
 startdb:
-	docker-compose -p $(PROJ) -f docker/docker-compose.yml up -d --no-recreate
+	docker compose -p $(PROJ) -f docker/docker-compose.yml up -d --no-recreate
 
 stopdb:
-	docker-compose -p $(PROJ) -f docker/docker-compose.yml down
+	docker compose -p $(PROJ) -f docker/docker-compose.yml down

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install cryptography --global-option=build_ext --global-option="-L/usr/local
 
 Building the Docker image is the recommended way to use OWTF so you do not have to worry about dependency conflicts or installing a large toolchain manually.
 
-- Install [`docker` and `docker-compose`](https://docs.docker.com/compose/install/).
+- Install Docker with the Compose plugin (`docker compose`).
 
 ```bash
 git clone https://github.com/owtf/owtf

--- a/docs/installation/methods.rst
+++ b/docs/installation/methods.rst
@@ -15,7 +15,7 @@ Docker
 ^^^^^^
 
 Docker automates the task of setting up owtf doing all the bootstraping it needs.
-Just make sure that you have ``docker`` and ``docker-compose`` installed and run:
+Just make sure that you have Docker with the Compose plugin (``docker compose``) installed and run:
 
 .. code-block:: bash
 

--- a/infra/aws-terraform/ec2.tf
+++ b/infra/aws-terraform/ec2.tf
@@ -75,14 +75,14 @@ resource "aws_instance" "ec2" {
               sudo apt update -y && sudo apt upgrade -y && sudo apt autoremove -y
               sudo snap install amazon-ssm-agent --classic
               sudo snap start amazon-ssm-agent
-              sudo apt install awscli software-properties-common apt-transport-https ca-certificates curl git docker-compose make -y
+              sudo apt install awscli software-properties-common apt-transport-https ca-certificates curl git make -y
               curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
               echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-              sudo apt-cache policy docker-ce && sudo apt install docker-ce -y
+              sudo apt-cache policy docker-ce && sudo apt install docker-ce docker-compose-plugin -y
               sudo usermod -aG docker ssm-user
               sudo systemctl restart docker
               git clone https://github.com/owtf/owtf.git
-              cd owtf && docker-compose -f docker/docker-compose.dev.yml up --build -d
+              cd owtf && docker compose -f docker/docker-compose.dev.yml up --build -d
               EOF
   depends_on = [aws_lb.alb, aws_vpc.vpc]
 }

--- a/infra/azure-terraform/outputs.tf
+++ b/infra/azure-terraform/outputs.tf
@@ -29,7 +29,7 @@ output "debug_commands" {
     ansible_rerun  = "export ANSIBLE_HOST_KEY_CHECKING=False && ansible-playbook -i inventory.ini owtf-setup.yml"
     setup_complete = "ssh -i ssh-keys/owtf-key ${var.admin_username}@${azurerm_public_ip.main.ip_address} 'ls -la /var/log/owtf-setup-complete'"
     docker_status  = "ssh -i ssh-keys/owtf-key ${var.admin_username}@${azurerm_public_ip.main.ip_address} 'sudo docker ps'"
-    owtf_logs      = "ssh -i ssh-keys/owtf-key ${var.admin_username}@${azurerm_public_ip.main.ip_address} 'cd owtf && docker-compose logs'"
+    owtf_logs      = "ssh -i ssh-keys/owtf-key ${var.admin_username}@${azurerm_public_ip.main.ip_address} 'cd owtf && docker compose logs'"
   }
   description = "Debug commands to monitor OWTF setup progress"
 }

--- a/infra/azure-terraform/owtf-setup.yml
+++ b/infra/azure-terraform/owtf-setup.yml
@@ -61,6 +61,7 @@
           - docker-ce
           - docker-ce-cli
           - containerd.io
+          - docker-compose-plugin
         state: present
         update_cache: yes
 
@@ -69,12 +70,6 @@
         name: "{{ admin_user }}"
         groups: docker
         append: yes
-
-    - name: Download Docker Compose
-      get_url:
-        url: "https://github.com/docker/compose/releases/download/v2.21.0/docker-compose-{{ ansible_system }}-{{ ansible_architecture }}"
-        dest: /usr/local/bin/docker-compose
-        mode: '0755'
 
     - name: Start and enable Docker
       systemd:
@@ -118,10 +113,10 @@
         group: "{{ admin_user }}"
         recurse: yes
 
-    - name: Start OWTF with Docker Compose
+    - name: Start OWTF with Docker Compose plugin
       shell: |
         cd /home/{{ admin_user }}/owtf
-        docker-compose -f docker/docker-compose.dev.yml up --build -d
+        docker compose -f docker/docker-compose.dev.yml up --build -d
       become_user: "{{ admin_user }}"
       environment:
         DOCKER_CLIENT_TIMEOUT: 300


### PR DESCRIPTION
## Summary
- Standardizes command usage on `docker compose` in maintained docs/automation.
- Aligns local dev runtime with the project baseline.

## Changes
- Updated `.devcontainer/devcontainer.json` Python feature version from `3.9` to `3.11`.
- Updated maintained command references from `docker-compose` to `docker compose` in:
  - `Makefile`
  - `README.md`
  - `docs/installation/methods.rst`
  - `infra/aws-terraform/ec2.tf`
  - `infra/azure-terraform/owtf-setup.yml`
  - `infra/azure-terraform/outputs.tf`
- Replaced manual Docker Compose binary download in Azure setup with `docker-compose-plugin` package usage.
- Updated AWS bootstrap package install to include `docker-compose-plugin`.

## Validation
- Verified maintained-path examples now use `docker compose`.
- Verified devcontainer Python baseline is now `3.11`.
