### PR TITLE
fix: replace collections.Mapping with collections.abc.Mapping

### DIFF
--- a/owtf/utils/http.py
+++ b/owtf/utils/http.py
@@ -3,7 +3,7 @@ owtf.utils.http
 ~~~~~~~~~~~~~~~
 
 """
-import collections
+import collections.abc
 import types
 
 try:  # PY3
@@ -41,7 +41,7 @@ def deep_update(source, overrides):
     :rtype: collections.Mapping
     """
     for key, value in overrides.items():
-        if isinstance(value, collections.Mapping) and value:
+        if isinstance(value, collections.abc.Mapping) and value:
             returned = deep_update(source.get(key, {}), value)
             source[key] = returned
         else:


### PR DESCRIPTION
## Fix Python 3.10+ compatibility issue

Fixes #1352

### Problem
OWTF crashes on Python 3.10+ with `AttributeError: module 'collections' has no attribute 'Mapping'` in the `deep_update()` function.

### Solution
Replaced `collections.Mapping` with `collections.abc.Mapping` (the correct location since Python 3.3). The old import path was deprecated in 3.3 and removed entirely in 3.10.

### Changes
- Updated import statement
- Updated isinstance check in deep_update()

Tested on Python 3.10 - no more crashes.