### PR TITLE
Phase 4: route auth sagas via shared history

### DIFF
--- a/owtf/webapp/src/containers/EmailVerification/saga.ts
+++ b/owtf/webapp/src/containers/EmailVerification/saga.ts
@@ -8,7 +8,7 @@ import {
   emailVerificationFail
 } from "./actions";
 import { toaster } from "evergreen-ui";
-import { push } from "react-router-redux";
+import history from "../../utils/historyUtils";
 
 /**
  * Send the email verification link to the email of the user using API
@@ -46,7 +46,7 @@ export function* postToVerificationAPI(action) {
       } else if (responseData.data["message"] === "Invalid Link") {
         pathname = "/signup";
       }
-      yield put(push(pathname));
+      yield call([history, history.push], pathname);
       toaster.success(responseData.data["message"]);
       yield put(emailVerificationSuccess(responseData.data["message"]));
     }

--- a/owtf/webapp/src/containers/ForgotPasswordPage/saga.ts
+++ b/owtf/webapp/src/containers/ForgotPasswordPage/saga.ts
@@ -3,7 +3,7 @@ import { forgotPasswordEmailSuccess, forgotPasswordEmailFail } from "./actions";
 import { FORGOT_PASSWORD_EMAIL_START } from "./constants";
 import { emailAPI } from "./api";
 import { toaster } from "evergreen-ui";
-import { push } from "react-router-redux";
+import history from "../../utils/historyUtils";
 
 export function* postDataToEmailAPI(action) {
   const postEmailAPI = emailAPI();
@@ -15,7 +15,7 @@ export function* postDataToEmailAPI(action) {
     const responseData = yield call(postEmailAPI, forgotPasswordData);
     if (responseData.data["status"] == "success") {
       toaster.success(responseData.data["message"]);
-      yield put(push("/forgot-password/otp/"));
+      yield call([history, history.push], "/forgot-password/otp/");
       yield put(
         forgotPasswordEmailSuccess(
           responseData.data["message"],

--- a/owtf/webapp/src/containers/LoginPage/saga.ts
+++ b/owtf/webapp/src/containers/LoginPage/saga.ts
@@ -3,8 +3,8 @@ import { loginFail, loginSuccess, logout } from "./actions";
 import { LOGIN_START, LOGIN_AUTO_CHECK, LOGOUT } from "./constants";
 import { loginUsingLoginAPI, logoutUsingLogoutAPI } from "./api";
 import jwt_decode from "jwt-decode";
-import { push } from "react-router-redux";
 import { toaster } from "evergreen-ui";
+import history from "../../utils/historyUtils";
 
 export function* postDataToLoginAPI(action) {
   const postLoginAPI = loginUsingLoginAPI();
@@ -25,7 +25,7 @@ export function* postDataToLoginAPI(action) {
         username = "Username";
       }
       yield put(loginSuccess(token, username));
-      yield put(push("/dashboard"));
+      yield call([history, history.push], "/dashboard");
     } else {
       yield put(loginFail(responseData.data["message"]));
       toaster.danger(responseData.data["message"]);
@@ -69,7 +69,7 @@ export function* postDataToLogoutAPI(action) {
     localStorage.removeItem("token");
     if (responseData.data["status"] == "success") {
       toaster.success("Logout Successful");
-      yield put(push("/"));
+      yield call([history, history.push], "/");
     }
   } catch (error) {
     toaster.danger("Server replied: " + error);

--- a/owtf/webapp/src/containers/NewPasswordPage/saga.ts
+++ b/owtf/webapp/src/containers/NewPasswordPage/saga.ts
@@ -2,8 +2,8 @@ import { call, put, takeLatest } from "redux-saga/effects";
 import { newPasswordSuccess, newPasswordFail } from "./actions";
 import { NEW_PASSWORD_START } from "./constants";
 import { newPasswordAPI } from "./api";
-import { push } from "react-router-redux";
 import { toaster } from "evergreen-ui";
+import history from "../../utils/historyUtils";
 
 export function* postDataToNewPasswordAPI(action) {
   const postNewPasswordAPI = newPasswordAPI();
@@ -19,7 +19,7 @@ export function* postDataToNewPasswordAPI(action) {
       yield put(
         newPasswordSuccess(responseData.data["message"], action.emailOrUsername)
       );
-      yield put(push("/login/"));
+      yield call([history, history.push], "/login/");
     } else {
       toaster.danger(responseData.data["message"]);
       yield put(newPasswordFail(responseData.data["message"]));

--- a/owtf/webapp/src/containers/OtpPage/saga.ts
+++ b/owtf/webapp/src/containers/OtpPage/saga.ts
@@ -2,8 +2,8 @@ import { call, put, takeLatest } from "redux-saga/effects";
 import { otpSuccess, otpFail } from "./actions";
 import { OTP_START } from "./constants";
 import { OtpVerifyAPI } from "./api";
-import { push } from "react-router-redux";
 import { toaster } from "evergreen-ui";
+import history from "../../utils/historyUtils";
 
 export function* postDataToOtpAPI(action) {
   const postOtpAPI = OtpVerifyAPI();
@@ -16,7 +16,7 @@ export function* postDataToOtpAPI(action) {
     if (responseData.data["status"] == "success") {
       toaster.success(responseData.data["message"]);
       yield put(otpSuccess(responseData.data["message"], action.otp));
-      yield put(push("/new-password/"));
+      yield call([history, history.push], "/new-password/");
     } else {
       toaster.danger(responseData.data["message"]);
       yield put(otpFail(responseData.data["message"]));

--- a/owtf/webapp/src/containers/SignupPage/saga.ts
+++ b/owtf/webapp/src/containers/SignupPage/saga.ts
@@ -3,8 +3,8 @@ import { signupFail, signupSuccess } from "./actions";
 import { emailSendStart } from "../EmailVerification/actions";
 import { SIGNUP_START } from "./constants";
 import { signupUsingSignupAPI } from "./api";
-import { push } from "react-router-redux";
 import { toaster } from "evergreen-ui";
+import history from "../../utils/historyUtils";
 
 /**
  * Create the signup of the user from API
@@ -22,7 +22,7 @@ export function* postDataToSignupAPI(action) {
     if (responseData.data["status"] == "success") {
       yield put(signupSuccess(responseData.data["message"], action.email));
       toaster.success(responseData.data["message"]);
-      yield put(push("/email-send/"));
+      yield call([history, history.push], "/email-send/");
       yield put(emailSendStart(signupData["email"]));
     } else {
       yield put(signupFail(responseData.data["message"]));


### PR DESCRIPTION
## Summary
- replace auth/onboarding saga redirects that dispatched `react-router-redux` `push(...)` actions with direct navigation via shared `history`
- update the following sagas:
  - `owtf/webapp/src/containers/EmailVerification/saga.ts`
  - `owtf/webapp/src/containers/ForgotPasswordPage/saga.ts`
  - `owtf/webapp/src/containers/LoginPage/saga.ts`
  - `owtf/webapp/src/containers/NewPasswordPage/saga.ts`
  - `owtf/webapp/src/containers/OtpPage/saga.ts`
  - `owtf/webapp/src/containers/SignupPage/saga.ts`

## Why
- this reduces direct runtime coupling to `react-router-redux` in saga code paths
- it is an incremental step toward full `react-router-redux` removal in Phase 4

## Validation
- frontend test suite passes locally:
  - `CI=true NODE_OPTIONS=--openssl-legacy-provider yarn test --runInBand --watch=false`
  - 18/18 suites passed
