### PR TITLE
Fix: Handle None case in activate_user() and change_password()

### DIFF
--- a/owtf/models/user.py
+++ b/owtf/models/user.py
@@ -58,8 +58,6 @@ class User(Model):
     @classmethod
     def activate_user(cls, session, user_id):
         db_obj = session.query(cls).filter_by(id=user_id).first()
-        if db_obj is None:
-            return None
         db_obj.is_active = True
         session.commit()
 
@@ -73,7 +71,5 @@ class User(Model):
     @classmethod
     def change_password(cls, session, email, password):
         db_obj = session.query(cls).filter_by(email=email).first()
-        if db_obj is None:
-            return None
         db_obj.password = password
         session.commit()

--- a/owtf/models/user.py
+++ b/owtf/models/user.py
@@ -58,6 +58,8 @@ class User(Model):
     @classmethod
     def activate_user(cls, session, user_id):
         db_obj = session.query(cls).filter_by(id=user_id).first()
+        if db_obj is None:
+            return None
         db_obj.is_active = True
         session.commit()
 
@@ -71,5 +73,7 @@ class User(Model):
     @classmethod
     def change_password(cls, session, email, password):
         db_obj = session.query(cls).filter_by(email=email).first()
+        if db_obj is None:
+            return None
         db_obj.password = password
         session.commit()


### PR DESCRIPTION
## Description
Added null checks in `activate_user()` and `change_password()` methods in `owtf/models/user.py` to prevent crashes when a user is not found in the database.

## Related Issue
#1376

## Motivation and Context
Both methods used `.first()` to query the database, which returns `None` when no record matches. Without a null check, the next line accessing `.is_active` or `.password` on `None` raises an `AttributeError`, crashing the app during account activation or password reset for non-existent users.

## Reviewers
@7a @viyatb 

## How Has This Been Tested?
Manually traced the code path for both `activate_user()` and `change_password()` with a non-existent user ID and email to confirm the crash. After the fix, the methods return `None` gracefully instead of raising an `AttributeError`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.