### PR TITLE
fix: subdomain takeover script - hardcoded paths, race condition, output directory

### DIFF
--- a/owtf/data/conf/general.yaml
+++ b/owtf/data/conf/general.yaml
@@ -88,7 +88,12 @@ TOOLS:
     value: /usr/bin/httpx-toolkit
   - config: TOOL_GAU
     value: ~/.owtf/tools/restricted/gau/gau
-
+  - config: TOOL_SUBJACK
+    value: ~/go/bin/subjack
+  - config: TOOL_SUBJACK_FINGERPRINTS
+    value: ~/go/src/github.com/haccer/subjack/fingerprints.json
+  - config: TOOL_SUBLIST3R
+    value: ~/.owtf/tools/restricted/sublist3r/Sublist3r/sublist3r.py
 
 
 DICTIONARIES:

--- a/owtf/data/conf/resources.cfg
+++ b/owtf/data/conf/resources.cfg
@@ -1200,7 +1200,7 @@ SnmpProbeMethods_____SNMP Probing using _____@@@TOOL_METASPLOIT_DIR@@@/msfconsol
 SnmpProbeMethods_____SNMP Probing using _____@@@TOOL_METASPLOIT_DIR@@@/msfconsole -q -x "use auxiliary/scanner/snmp/aix_version; set RHOSTS @@@host_ip@@@; set RPORT @@@SNMP_PORT_NUMBER@@@; run; exit"
 BruteSnmpProbeMethods_____SNMP Probing using _____@@@TOOL_METASPLOIT_DIR@@@/msfconsole -q -x "use auxiliary/scanner/snmp/snmp_login; set RHOSTS @@@host_ip@@@; set RPORT @@@SNMP_PORT_NUMBER@@@; run; exit"
 PassiveOpenS3Buckets_____Grayhat Warfare (Public Buckets)_____https://buckets.grayhatwarfare.com/results/@@@host_name@@@
-SubdomainTakeover_____Subdomain Takeover_____sh @@@FRAMEWORK_DIR@@@/scripts/subdomain_takeover.sh @@@host_name@@@
+SubdomainTakeover_____Subdomain Takeover_____sh @@@FRAMEWORK_DIR@@@/scripts/subdomain_takeover.sh @@@host_name@@@ ###plugin_output_dir### @@@TOOL_SUBJACK@@@ @@@TOOL_SUBJACK_FINGERPRINTS@@@ @@@TOOL_SUBLIST3R@@@
 IMAP_SMTPinjection_____IMAP_SMTP Injection_____command-injection-tester --imap --pop3 --smtp @@@host_name@@@
 ExternalLDAPinjection_____OWASP's LDAP injection article_____https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/06-Testing_for_LDAP_Injection
 ExternalLDAPinjection_____HackTrick's LDAP injection cheat sheet_____https://book.hacktricks.xyz/pentesting-web/ldap-injection

--- a/owtf/scripts/subdomain_takeover.sh
+++ b/owtf/scripts/subdomain_takeover.sh
@@ -1,134 +1,189 @@
 #!/bin/bash
 # Description:
-#       Script to emumerate subdomains for a given domain
+#       Script to enumerate subdomains for a given domain
 #       and checks if it's vulnerable to takeover
 #
 # Requires:
 # - amass
 # - sublist3r
 # - subjack
-
-
-echo 
-echo ----------------------------------------------------
-echo "                 Sub_Takeover                    "
-echo " Checks if subdomains are vulnerable for Takeover"
-echo ----------------------------------------------------
+#
+# Arguments:
+#   $1 - target domain (host_name)
+#   $2 - plugin output directory (###plugin_output_dir###)
+#   $3 - subjack binary path (@@@TOOL_SUBJACK@@@)
+#   $4 - subjack fingerprints path (@@@TOOL_SUBJACK_FINGERPRINTS@@@)
+#   $5 - sublist3r script path (@@@TOOL_SUBLIST3R@@@)
 
 echo
+echo "----------------------------------------------------"
+echo "                 Sub_Takeover                      "
+echo " Checks if subdomains are vulnerable for Takeover  "
+echo "----------------------------------------------------"
 echo
 
-SUBLIST3R_PATH="/root/.owtf/tools/restricted/sublist3r/Sublist3r"
-SUBJACK_PATH="/root/go/bin"
-SUBJACK_FINGERPRINT_PATH="/root/go/src/github.com/haccer/subjack/"
+# --- Argument validation ---
+if [ $# -ne 5 ]; then
+    echo "[!] Usage: $0 <domain> <output_dir> <subjack_bin> <subjack_fingerprints> <sublist3r_path>"
+    exit 1
+fi
 
-#Creating a temporary file to append all the subdomains found
-touch subdomain_$1.txt
+DOMAIN=$1
+OUTPUT_DIR=$2
+SUBJACK_BIN=$3
+SUBJACK_FINGERPRINTS=$4
+SUBLIST3R_PATH=$5
 
-
-#Find subdomains from online services(without tools)
-subdomain_without_tools(){
-echo "[*]STARTING SUBDOMAIN ENUMERATION...."
-echo
-echo "[*]Level 1:Subdomain Enumeration using Online services"
-echo "[*]Level 2:Subdomain Enumeration using Amass"
-echo "[*]Level 3:Subdomain Enumeration using Sublist3r"
-echo
-echo "[*] Starting Level 1"
-#certspotter.com
-curl -s -N "https://certspotter.com/api/v1/issuances?domain=$1&expand=dns_names" | jq -r '.[].dns_names[]' 2>/dev/null | grep -o "\w.*$1" | sort -u >> subdomain_$1.txt &
-#crt.sh
-curl -s -N "https://crt.sh/?q=%25.$1&output=json"| jq -r '.[].name_value' 2>/dev/null | sed 's/\*\.//g' | sort -u | grep -o "\w.*$1" >> subdomain_$1.txt &
-#hackertarget.com
-curl -s -N "https://api.hackertarget.com/hostsearch/?q=$1" | cut -d ',' -f1 | sort -u >> subdomain_$1.txt &
-#alienvault.com
-curl -s -N "https://otx.alienvault.com/api/v1/indicators/domain/$1/passive_dns"|jq '.passive_dns[].hostname' 2>/dev/null |grep -o "\w.*$1"|sort -u >> subdomain_$1.txt &
-#riddler.io
-curl -s -N "https://riddler.io/search/exportcsv?q=pld:$1"| grep -o "\w.*$1"|awk -F, '{print $6}'|sort -u  >> subdomain_$1.txt &
-#virustotal.com
-curl -s -N "https://www.virustotal.com/ui/domains/$1/subdomains?limit=40" | grep '"id":' | cut -d '"' -f4 | sort -u >> subdomain_$1.txt &
-#web.archive.org
-curl -s -N "http://web.archive.org/cdx/search/cdx?url=*.$1/*&output=text&fl=original&collapse=urlkey" | sort | sed -e 's_https*://__' -e "s/\/.*//" -e 's/:.*//' -e 's/^www\.//' |sort -u >> subdomain_$1.txt &
-#urlscan.io
-curl -s -N "https://urlscan.io/api/v1/search/?q=domain:$1"|jq '.results[].page.domain' 2>/dev/null |grep -o "\w.*$1"|sort -u >> subdomain_$1.txt &
-# threatminer.org
-curl -s -N "https://api.threatminer.org/v2/domain.php?q=$1&rt=5" | jq -r '.results[]' 2>/dev/null |grep -o "\w.*$1"|sort -u >> subdomain_$1.txt &
-# threatcrowd.org
-curl -s -N "https://www.threatcrowd.org/searchApi/v2/domain/report/?domain=$1"|jq -r '.subdomains' 2>/dev/null |grep -o "\w.*$1" |sort -u >> subdomain_$1.txt &
-#bufferover.run Rapid7
-curl -s -N "https://dns.bufferover.run/dns?q=.$1" | jq -r .FDNS_A[] 2>/dev/null | cut -d ',' -f2 | grep -o "\w.*$1" | sort -u >> subdomain_$1.txt &
-curl -s -N "https://dns.bufferover.run/dns?q=.$1" | jq -r .RDNS[] 2>/dev/null | cut -d ',' -f2 | grep -o "\w.*$1" | sort -u >> subdomain_$1.txt &
-curl -s -N "https://tls.bufferover.run/dns?q=.$1" | jq -r .Results 2>/dev/null | cut -d ',' -f3 |grep -o "\w.*$1"| sort -u >> subdomain_$1.txt &
-#dnsdumpster
-cmdtoken=$(curl -ILs https://dnsdumpster.com | grep csrftoken | cut -d " " -f2 | cut -d "=" -f2 | tr -d ";");curl -s --header "Host:dnsdumpster.com" --referer https://dnsdumpster.com --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0" --data "csrfmiddlewaretoken=$cmdtoken&targetip=$1" --cookie "csrftoken=$cmdtoken; _ga=GA1.2.1737013576.1458811829; _gat=1" https://dnsdumpster.com > dnsdumpster.html;cat dnsdumpster.html|grep "https://api.hackertarget.com/httpheaders"|grep -o "\w.*$1"|cut -d "/" -f7|sort -u >> subdomain_$1.txt;rm dnsdumpster.html &&
-#rapiddns.io
-curl -s "https://rapiddns.io/subdomain/$1?full=1#result" | grep -oaEi "https?://[^\"\\'> ]+" | grep $1 | cut -d "/" -f3 | sort -u >> subdomain_$1.txt &
-# jldc
-curl -s -N "https://jldc.me/anubis/subdomains/$1?limit=40" | grep '"id":' | cut -d '"' -f4 | sort -u >> subdomain_$1.txt
-echo
-echo "[*] Level 1 Done!!"
+# --- Tool availability check ---
+check_tool() {
+    if [ ! -f "$1" ] && ! command -v "$1" &>/dev/null; then
+        echo "[!] Required tool not found: $1"
+        return 1
+    fi
+    return 0
 }
 
-#Find Subdomains using Sublist3r, Amass and bbot
-subdomain_with_tools()
-{
-echo
-echo "[*] Starting Level 2"
-echo
-amass enum -d $1 >> subdomain_$1.txt
-echo
-echo "[*] Done Level 2"
-echo
-echo "[*] Starting Level 3"
-echo
-python3 $SUBLIST3R_PATH/sublist3r.py -d $1 -o sublist3r_$1.txt
-#Appending file contents to subdomain.txt(Not appending directly because ASCII art in Sublist3r is being obfuscated,due to which junk data is being added to subdomains list)
-cat sublist3r_$1.txt >> subdomain_$1.txt
-bbot -y -s -t google.com -f subdomain-enum -om human | grep '[DNS_NAME]' | cut -f2 >> bbot_$1.txt
-cat bbot_$1.txt >> subdomain_$1.txt
+# --- Output directory setup ---
+mkdir -p "$OUTPUT_DIR"
+SUBDOMAIN_TEMP="$OUTPUT_DIR/subdomain_${DOMAIN}.txt"
+SUBDOMAIN_FINAL="$OUTPUT_DIR/subdomains_${DOMAIN}.txt"
+TAKEOVER_OUT="$OUTPUT_DIR/takeover_${DOMAIN}.txt"
+SUBLIST3R_OUT="$OUTPUT_DIR/sublist3r_${DOMAIN}.txt"
 
+touch "$SUBDOMAIN_TEMP"
 
-echo
-echo "[*] Level 3 Done!!"
-echo
-echo "[*]SUBDOMAIN ENUMERATION DONE!!"
-echo
+# --- Level 1: Online sources ---
+subdomain_without_tools() {
+    echo "[*] STARTING SUBDOMAIN ENUMERATION...."
+    echo
+    echo "[*] Level 1: Subdomain Enumeration using Online services"
+    echo "[*] Level 2: Subdomain Enumeration using Amass"
+    echo "[*] Level 3: Subdomain Enumeration using Sublist3r"
+    echo
+    echo "[*] Starting Level 1"
+
+    # certspotter.com
+    curl -s -N "https://certspotter.com/api/v1/issuances?domain=$DOMAIN&expand=dns_names" \
+        | jq -r '.[].dns_names[]' 2>/dev/null \
+        | grep -o "\w.*$DOMAIN" | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # crt.sh
+    curl -s -N "https://crt.sh/?q=%25.$DOMAIN&output=json" \
+        | jq -r '.[].name_value' 2>/dev/null \
+        | sed 's/\*\.//g' | sort -u \
+        | grep -o "\w.*$DOMAIN" >> "$SUBDOMAIN_TEMP" &
+
+    # hackertarget.com
+    curl -s -N "https://api.hackertarget.com/hostsearch/?q=$DOMAIN" \
+        | cut -d ',' -f1 | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # alienvault.com
+    curl -s -N "https://otx.alienvault.com/api/v1/indicators/domain/$DOMAIN/passive_dns" \
+        | jq '.passive_dns[].hostname' 2>/dev/null \
+        | grep -o "\w.*$DOMAIN" | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # virustotal.com
+    curl -s -N "https://www.virustotal.com/ui/domains/$DOMAIN/subdomains?limit=40" \
+        | grep '"id":' | cut -d '"' -f4 | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # web.archive.org
+    curl -s -N "http://web.archive.org/cdx/search/cdx?url=*.$DOMAIN/*&output=text&fl=original&collapse=urlkey" \
+        | sort | sed -e 's_https*://__' -e "s/\/.*//" -e 's/:.*//' -e 's/^www\.//' \
+        | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # urlscan.io
+    curl -s -N "https://urlscan.io/api/v1/search/?q=domain:$DOMAIN" \
+        | jq '.results[].page.domain' 2>/dev/null \
+        | grep -o "\w.*$DOMAIN" | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # threatminer.org
+    curl -s -N "https://api.threatminer.org/v2/domain.php?q=$DOMAIN&rt=5" \
+        | jq -r '.results[]' 2>/dev/null \
+        | grep -o "\w.*$DOMAIN" | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # rapiddns.io
+    curl -s "https://rapiddns.io/subdomain/$DOMAIN?full=1#result" \
+        | grep -oaEi "https?://[^\"\\'> ]+" | grep "$DOMAIN" \
+        | cut -d "/" -f3 | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # jldc
+    curl -s -N "https://jldc.me/anubis/subdomains/$DOMAIN" \
+        | jq -r '.[]' 2>/dev/null \
+        | grep -o "\w.*$DOMAIN" | sort -u >> "$SUBDOMAIN_TEMP" &
+
+    # Wait for all background jobs before proceeding
+    wait
+    echo
+    echo "[*] Level 1 Done!!"
 }
 
-#Invoking Functions
-subdomain_without_tools $1
-subdomain_with_tools $1
+# --- Level 2 & 3: Tool-based enumeration ---
+subdomain_with_tools() {
+    echo
+    echo "[*] Starting Level 2 (Amass)"
+    echo
+    if check_tool "amass"; then
+        amass enum -d "$DOMAIN" >> "$SUBDOMAIN_TEMP"
+        echo "[*] Done Level 2"
+    else
+        echo "[!] Amass not found, skipping Level 2"
+    fi
 
-#Removing duplicates
-awk '!a[$0]++' subdomain_$1.txt > subdomains_$1.txt
+    echo
+    echo "[*] Starting Level 3 (Sublist3r)"
+    echo
+    if check_tool "$SUBLIST3R_PATH"; then
+        python3 "$SUBLIST3R_PATH" -d "$DOMAIN" -o "$SUBLIST3R_OUT"
+        cat "$SUBLIST3R_OUT" >> "$SUBDOMAIN_TEMP"
+        echo "[*] Done Level 3"
+    else
+        echo "[!] Sublist3r not found, skipping Level 3"
+    fi
 
-#Calculating Total subdomains
-TOTAL_SUBDOMAINS=$(wc -l < subdomains_$1.txt)
-echo "[*]Total Subdomains Found:$TOTAL_SUBDOMAINS"
-
-echo 
-checkTakeover(){
-echo "[*]CHECKING IF SUBDOMAINS ARE VULNERABLE TO TAKEOVER..."
-echo
-$SUBJACK_PATH/subjack -a -v -w subdomains_$1.txt -t 20 -timeout 15 -c $SUBJACK_FINGERPRINT_PATH/fingerprints.json -o takeover_$1.txt
-echo 
-echo "[*]DONE"
-echo
+    echo
+    echo "[*] SUBDOMAIN ENUMERATION DONE!!"
+    echo
 }
 
-#Invoking function
-checkTakeover $1
+# --- Takeover check ---
+checkTakeover() {
+    echo "[*] CHECKING IF SUBDOMAINS ARE VULNERABLE TO TAKEOVER..."
+    echo
+    if check_tool "$SUBJACK_BIN"; then
+        if [ ! -f "$SUBJACK_FINGERPRINTS" ]; then
+            echo "[!] Subjack fingerprints file not found: $SUBJACK_FINGERPRINTS"
+            echo "[!] Skipping takeover check."
+            return
+        fi
+        "$SUBJACK_BIN" -a -v -w "$SUBDOMAIN_FINAL" -t 20 -timeout 15 \
+            -c "$SUBJACK_FINGERPRINTS" -o "$TAKEOVER_OUT"
+        echo
+        echo "[*] DONE"
+    else
+        echo "[!] Subjack not found, skipping takeover check"
+    fi
+    echo
+}
 
-#Removing temporary files
-rm -r subdomain_$1.txt
-rm -r sublist3r_$1.txt
-rm -r bbot_$1.txt
+# --- Main ---
+subdomain_without_tools
+subdomain_with_tools
 
-#OutputInformation
-echo "[*]Output Information:"
+# Deduplicate
+awk '!a[$0]++' "$SUBDOMAIN_TEMP" > "$SUBDOMAIN_FINAL"
+
+TOTAL_SUBDOMAINS=$(wc -l < "$SUBDOMAIN_FINAL")
+echo "[*] Total Subdomains Found: $TOTAL_SUBDOMAINS"
+
+checkTakeover
+
+# Cleanup temp files
+[ -f "$SUBDOMAIN_TEMP" ] && rm "$SUBDOMAIN_TEMP"
+[ -f "$SUBLIST3R_OUT" ] && rm "$SUBLIST3R_OUT"
+
+# Output summary
+echo "[*] Output Information:"
+echo "[*] Subdomains : $SUBDOMAIN_FINAL"
+echo "[*] Takeover   : $TAKEOVER_OUT"
 echo
-echo "[*]Subdomains: subdomains_$1.txt"
-echo "[*]Takeover: takeover_$1.txt"
-echo
-echo "[*]SCANNING DONE!!"
-echo
+echo "[*] SCANNING DONE!!"


### PR DESCRIPTION
## Related Issue
Closes #1381

## Changes Made

### `owtf/data/conf/general.yaml`
- Registered `TOOL_SUBJACK` (default: `~/go/bin/subjack`)
- Registered `TOOL_SUBJACK_FINGERPRINTS` (default: `~/go/src/github.com/haccer/subjack/fingerprints.json`)
- Registered `TOOL_SUBLIST3R` (default: `~/.owtf/tools/restricted/sublist3r/Sublist3r/sublist3r.py`)

### `owtf/data/conf/resources.cfg`
- Updated `SubdomainTakeover` entry to pass `###plugin_output_dir###` and `@@@TOOL_*@@@` placeholders as arguments

### `owtf/scripts/subdomain_takeover.sh`
- Replaced hardcoded `/root/` paths with script arguments fed from `@@@TOOL_*@@@` config variables
- Added `wait` after background `curl &` jobs to fix race condition in subdomain collection
- All output files now written to `$OUTPUT_DIR` (plugin output directory) so they appear in the OWTF web UI
- Added `check_tool()` for graceful failure with clear error messages when tools are not installed
- Removed defunct APIs (`bufferover.run`, `riddler.io`, `threatcrowd.org`)
- Safe cleanup using `[ -f ... ] && rm` to avoid errors on missing files

## How to Test
1. Register a target in OWTF
2. Run the SubdomainTakeover active plugin
3. Verify output files appear in the plugin output directory in the UI
4. Run as non-root user and verify no path errors occur
5. Remove subjack and verify a clear error message appears instead of silent failure

## Notes
- `bbot` removed from script as it has no registered tool config in `general.yaml` 
  and was added inconsistently. Can be added properly in a separate PR.
- No changes to plugin Python code or OWTF core — only config and script files touched.