### PR TITLE
fix: filter result not assigned in get_plugin_output_dicts

### DIFF
--- a/owtf/managers/poutput.py
+++ b/owtf/managers/poutput.py
@@ -65,7 +65,7 @@ def poutput_gen_query(session, filter_data, target_id, for_delete=False):
     """
     query = session.query(PluginOutput).filter_by(target_id=target_id)
     if filter_data.get("target_id", None):
-        query.filter_by(target_id=filter_data["target_id"])
+        query = query.filter_by(target_id=filter_data["target_id"])
     if filter_data.get("plugin_key", None):
         if isinstance(filter_data.get("plugin_key"), str):
             query = query.filter_by(plugin_key=filter_data["plugin_key"])


### PR DESCRIPTION
## Description
`get_plugin_output_dicts()` in `owtf/managers/poutput.py` applies a `target_id` filter from `filter_data` but never assigns       
 the result back to `query`. The filtered query is discarded silently and unfiltered data is returned.

## Related Issue
Closes #1387

## Viewers
@7a @viyatb 

## Motivation and Context
SQLAlchemy's `filter_by()` returns a new query object it does not modify in place. Every other filter in the same function correctly assigns the result back to `query`, but line 68 was missing the assignment.

## How Has This Been Tested?
- Reviewed the code against all other filters in the same function.
- Confirmed `filter_by()` return value must be assigned in SQLAlchemy.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.