### PR TITLE
fix: replace deprecated logging.warn() with logging.warning() in owtf/shell/

### DIFF
--- a/owtf/shell/base.py
+++ b/owtf/shell/base.py
@@ -201,7 +201,7 @@ class BaseShell(object):
         except KeyboardInterrupt:
             os.killpg(proc.pid, signal.SIGINT)
             out, err = proc.communicate()
-            logging.warn(out.decode("utf-8"))
+            logging.warning(out.decode("utf-8"))
             output += out.decode("utf-8")
             try:
                 os.killpg(

--- a/owtf/shell/interactive.py
+++ b/owtf/shell/interactive.py
@@ -35,7 +35,7 @@ class InteractiveShell(BaseShell):
         :rtype: `bool`
         """
         if not self.connection:
-            logging.warn("ERROR - Communication channel closed - %s", abort_message)
+            logging.warning("ERROR - Communication channel closed - %s", abort_message)
             return False
         return True
 
@@ -53,7 +53,7 @@ class InteractiveShell(BaseShell):
         try:
             output = recv_some(self.connection, time)
         except DisconnectException:
-            logging.warn("ERROR: read - The Communication channel is down!")
+            logging.warning("ERROR: read - The Communication channel is down!")
             return output  # End of communication channel
         logging.info(output)  # Show progress on screen
         return output
@@ -97,7 +97,7 @@ class InteractiveShell(BaseShell):
             self.finish_cmd(self.session, cmd_info, cancelled, plugin_info)
         except DisconnectException:
             cancelled = True
-            logging.warn("ERROR: Run - The Communication Channel is down!")
+            logging.warning("ERROR: Run - The Communication Channel is down!")
             self.finish_cmd(self.session, cmd_info, cancelled, plugin_info)
         except KeyboardInterrupt:
             cancelled = True


### PR DESCRIPTION
## Description

Replace all `logging.warn()` calls in `owtf/shell/base.py` and `owtf/shell/interactive.py` with `logging.warning()`. `logging.warn()` has been deprecated since Python 3.2 and emits a `DeprecationWarning` on every call.

Changed call sites:
- `owtf/shell/base.py` line 204
- `owtf/shell/interactive.py` lines 38, 56, 100

## Related Issue

Closes #1406

## Motivation and Context

The project targets `python >= 3.11`. `logging.warn()` is deprecated and prints a `DeprecationWarning` on every call; `logging.warning()` is the correct, non-deprecated API.

**Correction (posted after initial submission):** this PR and its issue originally stated these calls raise `AttributeError: module 'logging' has no attribute 'warn'` on Python 3.12+. That was incorrect — verified against CPython that `logging.warn()` has never been removed from a released Python version (a removal targeted for Python 3.13 was reverted before that release shipped, see [cpython/cpython#105376](https://github.com/python/cpython/issues/105376)). This fix is still worth doing to eliminate the deprecation-warning noise and stay on the recommended API, just not for the crash reason originally stated. Apologies for not verifying that claim before opening.

## How Has This Been Tested?

Verified `grep -r 'logging\.warn(' owtf/shell/` returns no matches after the fix. Existing test suite passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
