### PR TITLE
fix: use pip install to reliably create owtf entrypoint binary

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -12,7 +12,7 @@ ENV SHELL=/bin/bash
 
 # Flush the buffer for stderr, stdout logging
 ENV PYTHONUNBUFFERED=1
-# Python won’t try to write .pyc or .pyo files on the import of source modules
+# Python won't try to write .pyc or .pyo files on the import of source modules
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # Needed for installation of pycurl using pip in kali
@@ -81,11 +81,15 @@ RUN pip install -r ${HOME}/requirements/base.txt
 COPY --chown=owtf:owtf bin ${HOME}/bin
 COPY --chown=owtf:owtf owtf ${HOME}/owtf
 COPY --chown=owtf:owtf requirements ${HOME}/requirements
-COPY --chown=owtf:owtf setup.py setup.cfg MANIFEST.in README.md ${HOME}/
+COPY --chown=owtf:owtf setup.py setup.cfg pyproject.toml MANIFEST.in README.md ${HOME}/
 
-# Install OWTF using the recommended method (setup.py)
+# Install OWTF using pip to ensure pyproject.toml entry points are created reliably
+# python setup.py install is deprecated and does not process pyproject.toml,
+# so the owtf console script was never created, causing PATH to resolve
+# 'owtf' to the package directory instead of a binary (exit code 126)
 RUN cd ${HOME} && \
-    python setup.py install
+    pip install . && \
+    which owtf
 
 # Reduce cache footprint from pip to keep final image size smaller
 RUN pip cache purge && rm -rf ${HOME}/.cache
@@ -110,6 +114,7 @@ COPY --from=owtf_setup /home/owtf/owtf ${HOME}/owtf
 COPY --from=owtf_setup /home/owtf/requirements ${HOME}/requirements
 COPY --from=owtf_setup /home/owtf/setup.py ${HOME}/setup.py
 COPY --from=owtf_setup /home/owtf/setup.cfg ${HOME}/setup.cfg
+COPY --from=owtf_setup /home/owtf/pyproject.toml ${HOME}/pyproject.toml
 COPY --from=owtf_setup /home/owtf/MANIFEST.in ${HOME}/MANIFEST.in
 COPY --from=owtf_setup /home/owtf/README.md ${HOME}/README.md
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ${HOME}/.owtf/data:/var/lib/postgresql/data
+      - ${HOME}/.owtf/data:/var/lib/postgresql
     environment:
       - POSTGRES_USER=owtf_db_user
       - POSTGRES_PASSWORD=jgZKW33Q+HZk8rqylZxaPg1lbuNGHJhgzsq3gBKV32g=

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ pyOpenSSL==23.3.0
 PyYAML==6.0.1
 requests==2.31.0
 selenium==4.18.1
-six==1.15.0
+six==1.16.0
 SQLAlchemy==1.4.54
 sqlalchemy_mixins==1.5.3
 tornado==6.2.0


### PR DESCRIPTION
python setup.py install is deprecated and does not process pyproject.toml, so the owtf console_script entry point was never created during Docker build. This caused PATH to resolve 'owtf' to the package directory instead of a binary, making wait-for-it.sh fail with exit code 126.

Fix:
- Copy pyproject.toml into build context
- Switch to pip install . which reads pyproject.toml and creates the owtf binary in VIRTUAL_ENV/bin/
- Update postgres volume mount path for PostgreSQL 18+ compatibility (/var/lib/postgresql instead of /data)
- Fix duplicate six dependency (1.15.0 vs 1.16.0) in setup.py

Fixes #1434

fix: resolve Docker backend exit 126 and PostgreSQL 18+ volume path

## Description

Fixes two issues preventing OWTF from running with Docker Compose:

1. Backend container exits immediately with code 126 (`exec: owtf: cannot execute: Is a directory`)
2. PostgreSQL container fails to initialize due to incorrect volume mount path on PG 18+

## Related Issue

Fixes #1434

## Motivation and Context

`python setup.py install` is deprecated and does not process `pyproject.toml`,
so the `owtf` console_script entry point was never created during the Docker build.
PATH resolves `owtf` to the package directory instead of an executable binary,
causing wait-for-it.sh to fail with exit code 126.

PostgreSQL 18+ expects data at `/var/lib/postgresql`, not `/var/lib/postgresql/data`.
The old volume mount path caused the postgres container to fail on startup.

## Reviewers
@dougmorato @citizen428 @csk

## How Has This Been Tested?

- Built with: docker compose -f docker/docker-compose.dev.yml up --build
- Backend starts successfully without exit code 126
- PostgreSQL container initializes and reaches healthy state
- owtf binary confirmed present in VIRTUAL_ENV/bin/ via `which owtf` during build

## Screenshots (if appropriate):
<!--- Before the change and after the change. -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other

### Checklist:

- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
