### PR TITLE
Fix Docker setup for Apple Silicon Macs and editable install

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,7 @@ The PRIMARY AUTHORS are:
 And here is an incomplete list of contributors who have submitted patches,
 reported bugs, provided ideas, helped answer questions, and generally made
 OWASP OWTF much better:
+ * Abhay Bansal @abhaybansal16
  * Adi Mutu @an_animal / @am06
  * Alessandro Fanio Gonzalez @alessandrofg
  * Alexandra Sandulescu

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -85,10 +85,10 @@ COPY --chown=owtf:owtf setup.py setup.cfg MANIFEST.in README.md ${HOME}/
 
 # Install OWTF using the recommended method (setup.py)
 RUN cd ${HOME} && \
-    python setup.py install
+    pip install -e .
 
 # Reduce cache footprint from pip to keep final image size smaller
-RUN pip cache purge && rm -rf ${HOME}/.cache
+RUN pip cache purge 2>/dev/null || true && rm -rf ${HOME}/.cache || true
 
 # Stage 3: Runtime image
 FROM base AS final_install

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -22,6 +22,8 @@ services:
     depends_on:
       - owtf-frontend
       - db
+    volumes:
+      - ~/.owtf:/home/owtf/.owtf
     networks:
       - backend
   owtf-frontend:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -24,6 +24,7 @@ services:
       - db
     volumes:
       - ~/.owtf:/home/owtf/.owtf
+      - ..:/home/owtf/owtf
     networks:
       - backend
   owtf-frontend:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,12 +3,13 @@ networks:
   backend: {}
 services:
   owtf-backend:
+    platform: linux/amd64
     container_name: owtf-backend
     restart: always
     build:
       context: ..
       dockerfile: docker/Dockerfile.backend
-    command: ["/usr/bin/wait-for-it.sh", "db:5432", "--", "owtf"]
+    command: ["/usr/bin/wait-for-it.sh", "db:5432", "--", "/home/owtf/bin/owtf"]
     environment:
       - DOCKER=1
       - POSTGRES_USER=owtf_db_user
@@ -21,11 +22,10 @@ services:
     depends_on:
       - owtf-frontend
       - db
-    volumes:
-      - ..:/home/owtf/owtf
     networks:
       - backend
   owtf-frontend:
+    platform: linux/amd64
     container_name: owtf-frontend
     restart: always
     build:
@@ -38,6 +38,7 @@ services:
     networks:
       - backend
   db:
+    platform: linux/amd64
     image: postgres:alpine
     ports:
       - 5432:5432


### PR DESCRIPTION
**Problem**
- Setup fails on Apple Silicon (M1/M2/M3) without platform: linux/amd64
- Backend crashes on start because python setup.py install creates an egg 
  that breaks config path resolution (regression from #1356)
- pip cache purge fails with permission error due to Rosetta cache directory
- owtf command path was wrong in wait-for-it.sh entrypoint

**Changes**
- Add platform: linux/amd64 to all services in docker-compose.dev.yml
- Switch to pip install -e . (aligns with editable install from #1356)
- Fix pip cache purge to handle permission errors gracefully
- Fix entrypoint command to use absolute path /home/owtf/bin/owtf

**Testing**
Verified on macOS with Apple Silicon (M1) — make compose-safe runs successfully and OWTF starts correctly.