### PR TITLE
Fix: Targets not showing in UI due to session_id bug

### DIFF
--- a/owtf/api/handlers/targets.py
+++ b/owtf/api/handlers/targets.py
@@ -4,6 +4,7 @@ owtf.api.handlers.targets
 
 """
 from owtf.api.handlers.base import APIRequestHandler
+from owtf.models.session import Session as OWTFSession
 from owtf.lib import exceptions
 from owtf.lib.exceptions import InvalidTargetReference, APIError
 from owtf.managers.target import (
@@ -64,11 +65,10 @@ class TargetConfigHandler(APIRequestHandler):
             }
         """
         try:
-            # If no target_id, means /target is accessed with or without filters
             if not target_id:
-                # Get all filter data here, so that it can be passed
                 filter_data = dict(self.request.arguments)
-                self.success(get_target_config_dicts(self.session, filter_data))
+                session_id = OWTFSession.get_active(self.session)
+                self.success(get_target_config_dicts(self.session, filter_data, session_id=session_id))
             else:
                 self.success(get_target_config_by_id(self.session, target_id))
         except InvalidTargetReference:

--- a/owtf/models/session.py
+++ b/owtf/models/session.py
@@ -28,8 +28,8 @@ class Session(Model):
 
     @classmethod
     def get_active(cls, session):
-        session_id = session.query(Session.id).filter_by(active=True).first()
-        return session_id
+        row = session.query(Session.id).filter_by(active=True).first()
+        return row[0] if row else None
 
     @classmethod
     def set_by_id(cls, session, session_id):

--- a/owtf/settings.py
+++ b/owtf/settings.py
@@ -70,9 +70,9 @@ AUX_TEST_GROUPS = os.path.join(OWTF_CONF, "conf", "profiles", "plugin_aux", "gro
 PLUGINS_DIR = os.path.join(ROOT_DIR, "plugins")
 
 # Output Settings
-OUTPUT_PATH = "owtf_review"
-AUX_OUTPUT_PATH = "owtf_review/auxiliary"
-NET_SCANS_PATH = "owtf_review/scans"
+OUTPUT_PATH = os.path.join(HOME_DIR, "owtf_review")
+AUX_OUTPUT_PATH = os.path.join(HOME_DIR, "owtf_review/auxiliary")
+NET_SCANS_PATH = os.path.join(HOME_DIR, "owtf_review/scans")
 
 # The name of the directories relative to output path
 TARGETS_DIR = "targets"

--- a/owtf/settings.py
+++ b/owtf/settings.py
@@ -70,9 +70,9 @@ AUX_TEST_GROUPS = os.path.join(OWTF_CONF, "conf", "profiles", "plugin_aux", "gro
 PLUGINS_DIR = os.path.join(ROOT_DIR, "plugins")
 
 # Output Settings
-OUTPUT_PATH = os.path.join(HOME_DIR, "owtf_review")
-AUX_OUTPUT_PATH = os.path.join(HOME_DIR, "owtf_review/auxiliary")
-NET_SCANS_PATH = os.path.join(HOME_DIR, "owtf_review/scans")
+OUTPUT_PATH = "owtf_review"
+AUX_OUTPUT_PATH = "owtf_review/auxiliary"
+NET_SCANS_PATH = "owtf_review/scans"
 
 # The name of the directories relative to output path
 TARGETS_DIR = "targets"


### PR DESCRIPTION
**Problem**

Two bugs prevented targets from working correctly in the UI:

1. `Session.get_active()` returned a SQLAlchemy `Row` object (a tuple) instead of a plain integer. Any code passing this to a DB query got `psycopg2: can't adapt type 'Row'` — an internal server error.

2. `TargetConfigHandler.get()` never passed `session_id` when calling `get_target_config_dicts()`, so the query filtered against `session_id=None` and returned no targets even when they existed in the DB.

**Changes**

* `owtf/models/session.py`: extract integer from Row in `get_active()`
* `owtf/api/handlers/targets.py`: pass active `session_id` when fetching targets

**Testing**

Verified on Docker (Apple Silicon, M4) — targets can be added via the UI and appear correctly in the targets table.