### PR TITLE
fix: replace deprecated logging.warn() and IOLoop.instance() in proxy startup

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -53,6 +53,7 @@ OWASP OWTF much better:
  * Robert Hansen @RSNake
  * Sachin Kamath @iamskamath - https://sachinwrites.xyz
  * Sandro Gauci @sandrogauci - http://www.enablesecurity.com
+ * Saurabh Gupta @saurabh4269 - https://saurabh4269.github.io/
  * Shadab Zafar
  * @sharad1126
  * Tapan Sharma

--- a/owtf/proxy/main.py
+++ b/owtf/proxy/main.py
@@ -187,7 +187,7 @@ class ProxyProcess(OWTFProcess):
             # To run any number of instances
             # "0" equals the number of cores present in a machine
             self.server.start(int(self.instances))
-            tornado.ioloop.IOLoop.instance().start()
+            tornado.ioloop.IOLoop.current().start()
         except BaseException:
             # Cleanup code
             self.clean_up()
@@ -199,7 +199,7 @@ class ProxyProcess(OWTFProcess):
         :rtype: None
         """
         self.server.stop()
-        tornado.ioloop.IOLoop.instance().stop()
+        tornado.ioloop.IOLoop.current().stop()
 
 
 def start_proxy():
@@ -221,7 +221,7 @@ def start_proxy():
             abort_framework("Inbound proxy address already in use")
         # If everything is fine.
         proxy_process = ProxyProcess()
-        logging.warn(
+        logging.warning(
             "Starting HTTP(s) proxy server at %s:%d",
             INBOUND_PROXY_IP,
             INBOUND_PROXY_PORT,


### PR DESCRIPTION
## Description
`owtf/proxy/main.py` used two deprecated APIs in the proxy start/stop path. This replaces:
- `logging.warn()` → `logging.warning()` in `start_proxy()`.
- `tornado.ioloop.IOLoop.instance()` → `IOLoop.current()` at both call sites (start in `pseudo_run()`, stop in `clean_up()`).

Both are the same class of deprecated-API fix in the same file, grouped into one PR.

## Related Issue
Fixes #1449

## Motivation and Context
`logging.warn()` has been deprecated since Python 3.2 and emits a `DeprecationWarning` on every call. It has not been removed from any released Python version (a proposed removal targeted for Python 3.13 was reverted before that release shipped, see [cpython#105376](https://github.com/python/cpython/issues/105376)). Replacing it with `logging.warning()` removes the deprecation-warning noise and keeps the code on the officially recommended API. `IOLoop.instance()` is deprecated since Tornado 5; `IOLoop.current()` is the documented API for the loop bound to the current context, which is the correct reference in the proxy's forked multiprocessing model and stays on the recommended API (`instance()` remains present in Tornado through at least 6.5.5, deprecated since Tornado 5.0 as a plain alias for `current()`, not removed).

**Correction (posted after initial submission):** the PR and issue originally stated `logging.warn()` was "removed in Python 3.12" and would crash the proxy with `AttributeError`. That was incorrect. I verified against CPython that this method has never actually been removed from a released Python version; there was a removal attempt reverted before Python 3.13 shipped. A first attempt at this correction also overstated the `IOLoop.instance()` side ("removed in newer Tornado") without checking; verified against the installed Tornado 6.5.5 source that `instance()` remains present, deprecated since 5.0 as a plain alias for `current()`, not removed. Both fixes are still worth doing (deprecation-warning cleanup and staying on the recommended API), just not for the crash/removal reasons originally stated. Apologies for not verifying either claim before opening.

## Reviewers
@viyatb @7a

## How Has This Been Tested?
Mechanical API replacements, same pattern as #1407/#1413. Confirmed `owtf/proxy/main.py` still compiles and no deprecated calls remain. No behaviour change beyond the deprecation fixes under the current single-IOLoop-per-process model. No test added, consistent with how #1405/#1407 (identical mechanical renames) were handled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [x] Tests, linting, and type checks pass locally (`owtf/proxy/main.py` is outside the linted `PY_QUALITY_PATHS` set).
- [x] I have added myself to AUTHORS.md (included in this PR).
