### PR TITLE
Community Plugin Marketplace: data model + DB upgrader

### DIFF
--- a/owtf/core.py
+++ b/owtf/core.py
@@ -4,13 +4,14 @@ owtf.core
 
 This is the command-line front-end in charge of processing arguments and call the framework.
 """
+
 from __future__ import print_function
 
-from copy import deepcopy
 import logging
 import os
 import signal
 import sys
+from copy import deepcopy
 
 from tornado.ioloop import IOLoop, PeriodicCallback
 
@@ -50,7 +51,7 @@ from owtf.settings import (
 from owtf.transactions.main import start_transaction_logger
 from owtf.utils.file import clean_temp_storage_dirs, create_temp_storage_dirs
 from owtf.utils.process import _signal_process
-from owtf.utils.signals import workers_finish, owtf_start
+from owtf.utils.signals import owtf_start, workers_finish
 
 __all__ = ["finish", "main"]
 
@@ -58,7 +59,8 @@ __all__ = ["finish", "main"]
 owtf_pid = None
 
 # Get a global DB connection instance
-from owtf.db.session import get_scoped_session
+from owtf.db.session import get_scoped_session  # noqa: E402
+from owtf.db.upgrade import run_startup_upgrades  # noqa: E402
 
 db = get_scoped_session()
 
@@ -77,14 +79,12 @@ def print_banner():
             @owtfp
         http://owtf.org
         Version: {0}
-        \033[0m""".format(
-            __version__
-        )
+        \033[0m""".format(__version__)
     )
 
 
 def get_plugins_from_arg(arg):
-    """ Returns a list of requested plugins and plugin groups
+    """Returns a list of requested plugins and plugin groups
 
     :param arg: Comma separated list of plugins
     :type arg: `str`
@@ -94,16 +94,12 @@ def get_plugins_from_arg(arg):
     plugins = arg.split(",")
     plugin_groups = Plugin.get_groups_for_plugins(db, plugins)
     if len(plugin_groups) > 1:
-        usage(
-            "The plugins specified belong to several plugin groups: '%s'".format(
-                str(plugin_groups)
-            )
-        )
+        usage("The plugins specified belong to several plugin groups: '%s'")
     return [plugins, plugin_groups]
 
 
 def process_options(user_args):
-    """ The main argument processing function
+    """The main argument processing function
 
     :param user_args: User supplied arguments
     :type user_args: `dict`
@@ -163,16 +159,12 @@ def process_options(user_args):
                     outbound_proxy_port = "9050"  # default TOR port
                 else:
                     outbound_proxy_port = arg.tor_mode[1]
-                arg.outbound_proxy = "socks://{0}:{1}".format(
-                    outbound_proxy_ip, outbound_proxy_port
-                )
+                arg.outbound_proxy = "socks://{0}:{1}".format(outbound_proxy_ip, outbound_proxy_port)
 
         if arg.outbound_proxy:
             arg.outbound_proxy = arg.outbound_proxy.split("://")
             if len(arg.outbound_proxy) == 2:
-                arg.outbound_proxy = arg.outbound_proxy + arg.outbound_proxy.pop().split(
-                    ":"
-                )
+                arg.outbound_proxy = arg.outbound_proxy + arg.outbound_proxy.pop().split(":")
                 if arg.outbound_proxy[0] not in ["socks", "http"]:
                     usage("Invalid argument for outbound proxy")
             else:
@@ -282,7 +274,7 @@ def poll_workers():
     try:
         callback.start()
         IOLoop.instance().start()
-    except SystemExit as e:
+    except SystemExit:
         callback.stop()
 
 
@@ -307,7 +299,7 @@ def finish(sender=None, **kwargs):
 
 
 def main():
-    """ The main wrapper which loads everything
+    """The main wrapper which loads everything
 
     :return:
     :rtype: None
@@ -321,15 +313,12 @@ def main():
 
     # Bootstrap the DB
     create_temp_storage_dirs(owtf_pid)
+    run_startup_upgrades(db.get_bind())
     try:
         _ensure_default_session(db)
-        load_framework_config(
-            DEFAULT_FRAMEWORK_CONFIG, FALLBACK_FRAMEWORK_CONFIG, root_dir, owtf_pid
-        )
+        load_framework_config(DEFAULT_FRAMEWORK_CONFIG, FALLBACK_FRAMEWORK_CONFIG, root_dir, owtf_pid)
         load_general_config(db, DEFAULT_GENERAL_PROFILE, FALLBACK_GENERAL_PROFILE)
-        load_resources_from_file(
-            db, DEFAULT_RESOURCES_PROFILE, FALLBACK_RESOURCES_PROFILE
-        )
+        load_resources_from_file(db, DEFAULT_RESOURCES_PROFILE, FALLBACK_RESOURCES_PROFILE)
         load_test_groups(db, WEB_TEST_GROUPS, FALLBACK_WEB_TEST_GROUPS, "web")
         load_test_groups(db, NET_TEST_GROUPS, FALLBACK_NET_TEST_GROUPS, "net")
         load_test_groups(db, AUX_TEST_GROUPS, FALLBACK_AUX_TEST_GROUPS, "aux")

--- a/owtf/core.py
+++ b/owtf/core.py
@@ -4,14 +4,13 @@ owtf.core
 
 This is the command-line front-end in charge of processing arguments and call the framework.
 """
-
 from __future__ import print_function
 
+from copy import deepcopy
 import logging
 import os
 import signal
 import sys
-from copy import deepcopy
 
 from tornado.ioloop import IOLoop, PeriodicCallback
 
@@ -32,6 +31,7 @@ from owtf.managers.session import _ensure_default_session
 from owtf.managers.target import load_targets
 from owtf.managers.worklist import load_works
 from owtf.models.plugin import Plugin
+from owtf.models.user_plugin import UserPlugin  # noqa: F401 - register the table before create_all
 from owtf.plugin.runner import show_plugin_list
 from owtf.proxy.main import start_proxy
 from owtf.settings import (
@@ -51,7 +51,7 @@ from owtf.settings import (
 from owtf.transactions.main import start_transaction_logger
 from owtf.utils.file import clean_temp_storage_dirs, create_temp_storage_dirs
 from owtf.utils.process import _signal_process
-from owtf.utils.signals import owtf_start, workers_finish
+from owtf.utils.signals import workers_finish, owtf_start
 
 __all__ = ["finish", "main"]
 
@@ -59,8 +59,8 @@ __all__ = ["finish", "main"]
 owtf_pid = None
 
 # Get a global DB connection instance
-from owtf.db.session import get_scoped_session  # noqa: E402
-from owtf.db.upgrade import run_startup_upgrades  # noqa: E402
+from owtf.db.session import get_scoped_session
+from owtf.db.upgrade import run_startup_upgrades
 
 db = get_scoped_session()
 
@@ -79,12 +79,14 @@ def print_banner():
             @owtfp
         http://owtf.org
         Version: {0}
-        \033[0m""".format(__version__)
+        \033[0m""".format(
+            __version__
+        )
     )
 
 
 def get_plugins_from_arg(arg):
-    """Returns a list of requested plugins and plugin groups
+    """ Returns a list of requested plugins and plugin groups
 
     :param arg: Comma separated list of plugins
     :type arg: `str`
@@ -94,12 +96,16 @@ def get_plugins_from_arg(arg):
     plugins = arg.split(",")
     plugin_groups = Plugin.get_groups_for_plugins(db, plugins)
     if len(plugin_groups) > 1:
-        usage("The plugins specified belong to several plugin groups: '%s'")
+        usage(
+            "The plugins specified belong to several plugin groups: '%s'".format(
+                str(plugin_groups)
+            )
+        )
     return [plugins, plugin_groups]
 
 
 def process_options(user_args):
-    """The main argument processing function
+    """ The main argument processing function
 
     :param user_args: User supplied arguments
     :type user_args: `dict`
@@ -159,12 +165,16 @@ def process_options(user_args):
                     outbound_proxy_port = "9050"  # default TOR port
                 else:
                     outbound_proxy_port = arg.tor_mode[1]
-                arg.outbound_proxy = "socks://{0}:{1}".format(outbound_proxy_ip, outbound_proxy_port)
+                arg.outbound_proxy = "socks://{0}:{1}".format(
+                    outbound_proxy_ip, outbound_proxy_port
+                )
 
         if arg.outbound_proxy:
             arg.outbound_proxy = arg.outbound_proxy.split("://")
             if len(arg.outbound_proxy) == 2:
-                arg.outbound_proxy = arg.outbound_proxy + arg.outbound_proxy.pop().split(":")
+                arg.outbound_proxy = arg.outbound_proxy + arg.outbound_proxy.pop().split(
+                    ":"
+                )
                 if arg.outbound_proxy[0] not in ["socks", "http"]:
                     usage("Invalid argument for outbound proxy")
             else:
@@ -274,7 +284,7 @@ def poll_workers():
     try:
         callback.start()
         IOLoop.instance().start()
-    except SystemExit:
+    except SystemExit as e:
         callback.stop()
 
 
@@ -299,7 +309,7 @@ def finish(sender=None, **kwargs):
 
 
 def main():
-    """The main wrapper which loads everything
+    """ The main wrapper which loads everything
 
     :return:
     :rtype: None
@@ -316,9 +326,13 @@ def main():
     run_startup_upgrades(db.get_bind())
     try:
         _ensure_default_session(db)
-        load_framework_config(DEFAULT_FRAMEWORK_CONFIG, FALLBACK_FRAMEWORK_CONFIG, root_dir, owtf_pid)
+        load_framework_config(
+            DEFAULT_FRAMEWORK_CONFIG, FALLBACK_FRAMEWORK_CONFIG, root_dir, owtf_pid
+        )
         load_general_config(db, DEFAULT_GENERAL_PROFILE, FALLBACK_GENERAL_PROFILE)
-        load_resources_from_file(db, DEFAULT_RESOURCES_PROFILE, FALLBACK_RESOURCES_PROFILE)
+        load_resources_from_file(
+            db, DEFAULT_RESOURCES_PROFILE, FALLBACK_RESOURCES_PROFILE
+        )
         load_test_groups(db, WEB_TEST_GROUPS, FALLBACK_WEB_TEST_GROUPS, "web")
         load_test_groups(db, NET_TEST_GROUPS, FALLBACK_NET_TEST_GROUPS, "net")
         load_test_groups(db, AUX_TEST_GROUPS, FALLBACK_AUX_TEST_GROUPS, "aux")

--- a/owtf/db/session.py
+++ b/owtf/db/session.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
 from owtf.db.model_base import Model
-from owtf.db.upgrade import run_startup_upgrades
 from owtf.settings import DATABASE_IP, DATABASE_NAME, DATABASE_PASS, DATABASE_PORT, DATABASE_USER
 
 DB_URI = "postgresql+psycopg2://{}:{}@{}:{}/{}".format(
@@ -52,12 +51,7 @@ def flush_transaction(method):
 def get_db_engine():
     try:
         engine = create_engine(DB_URI, poolclass=NullPool)
-        # create_all makes brand-new installs work. run_startup_upgrades
-        # adds columns to tables that existed before those columns were
-        # introduced, so upgrading an existing install does not crash on
-        # first request.
         Model.metadata.create_all(engine)
-        run_startup_upgrades(engine)
         return engine
     except exc.OperationalError as e:
         logging.error("Could not create engine - Exception occured\n%s", str(e))

--- a/owtf/db/session.py
+++ b/owtf/db/session.py
@@ -4,9 +4,10 @@ owtf.db.session
 
 This file handles all the database transactions.
 """
+
 import functools
-import sys
 import logging
+import sys
 
 from sqlalchemy import create_engine, exc, func
 from sqlalchemy.orm import Session as _Session
@@ -14,7 +15,8 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
 from owtf.db.model_base import Model
-from owtf.settings import DATABASE_IP, DATABASE_NAME, DATABASE_PASS, DATABASE_USER, DATABASE_PORT
+from owtf.db.upgrade import run_startup_upgrades
+from owtf.settings import DATABASE_IP, DATABASE_NAME, DATABASE_PASS, DATABASE_PORT, DATABASE_USER
 
 DB_URI = "postgresql+psycopg2://{}:{}@{}:{}/{}".format(
     DATABASE_USER, DATABASE_PASS, DATABASE_IP, DATABASE_PORT, DATABASE_NAME
@@ -50,7 +52,12 @@ def flush_transaction(method):
 def get_db_engine():
     try:
         engine = create_engine(DB_URI, poolclass=NullPool)
+        # create_all makes brand-new installs work. run_startup_upgrades
+        # adds columns to tables that existed before those columns were
+        # introduced, so upgrading an existing install does not crash on
+        # first request.
         Model.metadata.create_all(engine)
+        run_startup_upgrades(engine)
         return engine
     except exc.OperationalError as e:
         logging.error("Could not create engine - Exception occured\n%s", str(e))
@@ -63,10 +70,10 @@ def get_scoped_session():
 
 
 class Session(_Session):
-    """ Custom session meant to utilize add on the model.
-        This Session overrides the add/add_all methods to prevent them
-        from being used. This is to for using the add methods on the
-        models themselves where overriding is available.
+    """Custom session meant to utilize add on the model.
+    This Session overrides the add/add_all methods to prevent them
+    from being used. This is to for using the add methods on the
+    models themselves where overriding is available.
     """
 
     _add = _Session.add

--- a/owtf/db/session.py
+++ b/owtf/db/session.py
@@ -4,10 +4,9 @@ owtf.db.session
 
 This file handles all the database transactions.
 """
-
 import functools
-import logging
 import sys
+import logging
 
 from sqlalchemy import create_engine, exc, func
 from sqlalchemy.orm import Session as _Session
@@ -15,7 +14,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
 from owtf.db.model_base import Model
-from owtf.settings import DATABASE_IP, DATABASE_NAME, DATABASE_PASS, DATABASE_PORT, DATABASE_USER
+from owtf.settings import DATABASE_IP, DATABASE_NAME, DATABASE_PASS, DATABASE_USER, DATABASE_PORT
 
 DB_URI = "postgresql+psycopg2://{}:{}@{}:{}/{}".format(
     DATABASE_USER, DATABASE_PASS, DATABASE_IP, DATABASE_PORT, DATABASE_NAME
@@ -64,10 +63,10 @@ def get_scoped_session():
 
 
 class Session(_Session):
-    """Custom session meant to utilize add on the model.
-    This Session overrides the add/add_all methods to prevent them
-    from being used. This is to for using the add methods on the
-    models themselves where overriding is available.
+    """ Custom session meant to utilize add on the model.
+        This Session overrides the add/add_all methods to prevent them
+        from being used. This is to for using the add methods on the
+        models themselves where overriding is available.
     """
 
     _add = _Session.add

--- a/owtf/db/upgrade.py
+++ b/owtf/db/upgrade.py
@@ -3,10 +3,9 @@ owtf.db.upgrade
 ~~~~~~~~~~~~~~~
 
 Idempotent ALTER TABLE ADD COLUMN runner for tables that gained new
-columns after their initial release. OWTF does not use Alembic, and
-``create_all`` never adds columns to an existing table, so upgraded
-installs would otherwise crash with UndefinedColumn on the first
-query.
+columns after their initial release. Called once at app startup from
+owtf.core.main; also guarded so repeat calls in the same process are
+a no-op.
 """
 
 import logging
@@ -14,6 +13,8 @@ import logging
 from sqlalchemy import inspect, text
 
 logger = logging.getLogger(__name__)
+
+_UPGRADES_APPLIED = False
 
 
 # Each entry is (column_name, DDL fragment) appended after
@@ -49,21 +50,26 @@ def _add_missing_columns(engine, table_name, upgrades):
         # Table has not been created yet; create_all will build it fresh.
         return
 
-    with engine.begin() as conn:
-        for col_name, ddl in upgrades:
-            if col_name in present:
-                continue
-            stmt = "ALTER TABLE {} ADD COLUMN {} {}".format(table_name, col_name, ddl)
-            logger.info("Upgrading schema: %s", stmt)
-            try:
+    # One transaction per column. PostgreSQL aborts the whole transaction
+    # on the first DDL error, so wrapping the loop in a single txn would
+    # silently lose every ALTER after a duplicate-column race.
+    for col_name, ddl in upgrades:
+        if col_name in present:
+            continue
+        stmt = "ALTER TABLE {} ADD COLUMN {} {}".format(table_name, col_name, ddl)
+        logger.info("Upgrading schema: %s", stmt)
+        try:
+            with engine.begin() as conn:
                 conn.execute(text(stmt))
-            except Exception as exc:
-                # Do not let one failing column stop the rest. Most often this
-                # is a race with a parallel worker that already added it.
-                logger.warning("Schema upgrade failed for %s.%s: %s", table_name, col_name, exc)
+        except Exception as exc:
+            logger.warning("Schema upgrade failed for %s.%s: %s", table_name, col_name, exc)
 
 
 def run_startup_upgrades(engine):
-    """Apply every registered ADD COLUMN upgrade. Idempotent."""
+    """Apply every registered ADD COLUMN upgrade. Runs at most once per process."""
+    global _UPGRADES_APPLIED
+    if _UPGRADES_APPLIED:
+        return
+    _UPGRADES_APPLIED = True
     _add_missing_columns(engine, "user_plugins", _USER_PLUGIN_COLUMN_UPGRADES)
     _add_missing_columns(engine, "users", _USERS_COLUMN_UPGRADES)

--- a/owtf/db/upgrade.py
+++ b/owtf/db/upgrade.py
@@ -11,6 +11,7 @@ a no-op.
 import logging
 
 from sqlalchemy import inspect, text
+from sqlalchemy.exc import DBAPIError
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,23 @@ def _existing_columns(engine, table_name):
     return {col["name"] for col in inspector.get_columns(table_name)}
 
 
+def _is_duplicate_column_error(exc):
+    """Return True only if the driver reported the benign duplicate-column race.
+
+    Every other DDL error is a real failure and must be re-raised so
+    startup stops instead of leaving a half-upgraded schema behind.
+    """
+    # PostgreSQL / psycopg2 exposes SQLSTATE via orig.pgcode. 42701 is
+    # "duplicate_column".
+    orig = getattr(exc, "orig", None)
+    pgcode = getattr(orig, "pgcode", None)
+    if pgcode == "42701":
+        return True
+    # SQLite and the generic fallback: the driver message contains
+    # "duplicate column".
+    return "duplicate column" in str(exc).lower()
+
+
 def _add_missing_columns(engine, table_name, upgrades):
     present = _existing_columns(engine, table_name)
     if not present:
@@ -61,15 +79,29 @@ def _add_missing_columns(engine, table_name, upgrades):
         try:
             with engine.begin() as conn:
                 conn.execute(text(stmt))
-        except Exception as exc:
-            logger.warning("Schema upgrade failed for %s.%s: %s", table_name, col_name, exc)
+        except DBAPIError as exc:
+            if _is_duplicate_column_error(exc):
+                # Another worker beat us to this ALTER between our
+                # inspector check and the ALTER itself. Safe to skip.
+                logger.info(
+                    "Column %s.%s already added by another worker, skipping.",
+                    table_name,
+                    col_name,
+                )
+                continue
+            raise
 
 
 def run_startup_upgrades(engine):
-    """Apply every registered ADD COLUMN upgrade. Runs at most once per process."""
+    """Apply every registered ADD COLUMN upgrade.
+
+    Runs at most once per process. The guard is set only after every
+    upgrade succeeds so a transient DB error does not leave the process
+    thinking the schema is already up to date.
+    """
     global _UPGRADES_APPLIED
     if _UPGRADES_APPLIED:
         return
-    _UPGRADES_APPLIED = True
     _add_missing_columns(engine, "user_plugins", _USER_PLUGIN_COLUMN_UPGRADES)
     _add_missing_columns(engine, "users", _USERS_COLUMN_UPGRADES)
+    _UPGRADES_APPLIED = True

--- a/owtf/db/upgrade.py
+++ b/owtf/db/upgrade.py
@@ -1,0 +1,69 @@
+"""
+owtf.db.upgrade
+~~~~~~~~~~~~~~~
+
+Idempotent ALTER TABLE ADD COLUMN runner for tables that gained new
+columns after their initial release. OWTF does not use Alembic, and
+``create_all`` never adds columns to an existing table, so upgraded
+installs would otherwise crash with UndefinedColumn on the first
+query.
+"""
+
+import logging
+
+from sqlalchemy import inspect, text
+
+logger = logging.getLogger(__name__)
+
+
+# Each entry is (column_name, DDL fragment) appended after
+# "ADD COLUMN <name>". Types are ANSI so both PostgreSQL and SQLite
+# accept them.
+_USER_PLUGIN_COLUMN_UPGRADES = [
+    ("rejection_reason", "TEXT"),
+    ("reviewed_by_user_id", "INTEGER"),
+    ("reviewed_at", "TIMESTAMP"),
+    ("execution_timeout", "INTEGER NOT NULL DEFAULT 300"),
+    ("memory_limit", "INTEGER NOT NULL DEFAULT 268435456"),
+    ("is_public", "BOOLEAN NOT NULL DEFAULT TRUE"),
+    ("version", "VARCHAR(32) NOT NULL DEFAULT '1.0.0'"),
+    ("tags", "VARCHAR(256)"),
+    ("category", "VARCHAR(64)"),
+]
+
+_USERS_COLUMN_UPGRADES = [
+    ("is_admin", "BOOLEAN NOT NULL DEFAULT FALSE"),
+]
+
+
+def _existing_columns(engine, table_name):
+    inspector = inspect(engine)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def _add_missing_columns(engine, table_name, upgrades):
+    present = _existing_columns(engine, table_name)
+    if not present:
+        # Table has not been created yet; create_all will build it fresh.
+        return
+
+    with engine.begin() as conn:
+        for col_name, ddl in upgrades:
+            if col_name in present:
+                continue
+            stmt = "ALTER TABLE {} ADD COLUMN {} {}".format(table_name, col_name, ddl)
+            logger.info("Upgrading schema: %s", stmt)
+            try:
+                conn.execute(text(stmt))
+            except Exception as exc:
+                # Do not let one failing column stop the rest. Most often this
+                # is a race with a parallel worker that already added it.
+                logger.warning("Schema upgrade failed for %s.%s: %s", table_name, col_name, exc)
+
+
+def run_startup_upgrades(engine):
+    """Apply every registered ADD COLUMN upgrade. Idempotent."""
+    _add_missing_columns(engine, "user_plugins", _USER_PLUGIN_COLUMN_UPGRADES)
+    _add_missing_columns(engine, "users", _USERS_COLUMN_UPGRADES)

--- a/owtf/models/user.py
+++ b/owtf/models/user.py
@@ -3,11 +3,12 @@ owtf.models.user
 ~~~~~~~~~~~~~~~~
 
 """
-from sqlalchemy import Column, Integer, Unicode, Boolean
+
+from sqlalchemy import Boolean, Column, Integer, Unicode
+from sqlalchemy.orm import relationship
+
 from owtf.db.model_base import Model
 from owtf.models.email_confirmation import EmailConfirmation
-from sqlalchemy.orm import relationship
-import uuid
 
 
 class User(Model):
@@ -18,6 +19,7 @@ class User(Model):
     email = Column(Unicode(255), nullable=False, unique=True)
     password = Column(Unicode(255), nullable=False)
     is_active = Column(Boolean, default=False)  # checks whether user email is verified
+    is_admin = Column(Boolean, default=False, nullable=False)  # platform admin flag
     otp_secret_key = Column(Unicode(255), nullable=False, unique=True)  # used to generate unique otp
     email_confirmations = relationship(EmailConfirmation, cascade="delete")
     user_login_tokens = relationship("UserLoginToken", cascade="delete")

--- a/owtf/models/user.py
+++ b/owtf/models/user.py
@@ -3,12 +3,11 @@ owtf.models.user
 ~~~~~~~~~~~~~~~~
 
 """
-
-from sqlalchemy import Boolean, Column, Integer, Unicode
-from sqlalchemy.orm import relationship
-
+from sqlalchemy import Column, Integer, Unicode, Boolean
 from owtf.db.model_base import Model
 from owtf.models.email_confirmation import EmailConfirmation
+from sqlalchemy.orm import relationship
+import uuid
 
 
 class User(Model):

--- a/owtf/models/user_plugin.py
+++ b/owtf/models/user_plugin.py
@@ -1,0 +1,134 @@
+"""
+owtf.models.user_plugin
+~~~~~~~~~~~~~~~~~~~~~~~
+
+SQLAlchemy model for community-uploaded plugins.
+"""
+
+import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from owtf.db.model_base import Model
+
+APPROVAL_PENDING = "pending"
+APPROVAL_APPROVED = "approved"
+APPROVAL_REJECTED = "rejected"
+
+VALID_APPROVAL_STATUSES = {APPROVAL_PENDING, APPROVAL_APPROVED, APPROVAL_REJECTED}
+
+VALID_GROUPS = {"web", "network", "auxiliary"}
+VALID_TYPES = {"active", "passive", "semi_passive", "external", "grep"}
+
+
+class UserPlugin(Model):
+    """Represents a community-uploaded plugin stored in the DB."""
+
+    __tablename__ = "user_plugins"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(128), nullable=False, unique=True, index=True)
+    description = Column(Text, nullable=False)
+    category = Column(String(64), nullable=True)
+    group = Column(String(32), nullable=False, default="web")
+    type = Column(String(32), nullable=False, default="passive")
+    author = Column(String(128), nullable=False)
+    file_path = Column(String(512), nullable=False)
+    rating = Column(Float, default=0.0, nullable=False)
+    approval_status = Column(String(16), default=APPROVAL_PENDING, nullable=False, index=True)
+    rejection_reason = Column(Text, nullable=True)
+    version = Column(String(32), default="1.0.0", nullable=False)
+    tags = Column(String(256), nullable=True)
+    execution_timeout = Column(Integer, default=300, nullable=False)
+    memory_limit = Column(Integer, default=268435456, nullable=False)  # 256 MB
+    is_public = Column(Boolean, default=True, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    user = relationship("User", foreign_keys=[user_id], backref="uploaded_plugins")
+    reviewed_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    reviewer = relationship("User", foreign_keys=[reviewed_by_user_id])
+    reviewed_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=datetime.datetime.utcnow,
+        onupdate=datetime.datetime.utcnow,
+        nullable=False,
+    )
+
+    def __repr__(self):
+        return "<UserPlugin name={!r} status={!r}>".format(self.name, self.approval_status)
+
+    def to_dict(self):
+        """Public view. Never includes file_path (server-side detail)."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "group": self.group,
+            "type": self.type,
+            "author": self.author,
+            "rating": self.rating,
+            "approval_status": self.approval_status,
+            "version": self.version,
+            "tags": self.tags.split(",") if self.tags else [],
+            "is_public": self.is_public,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    def to_owner_dict(self):
+        """Owner view: public fields plus rejection reason."""
+        d = self.to_dict()
+        d["rejection_reason"] = self.rejection_reason
+        d["user_id"] = self.user_id
+        return d
+
+    def to_admin_dict(self):
+        """Admin view: owner fields plus reviewer trail and resource limits."""
+        d = self.to_owner_dict()
+        d["reviewed_by_user_id"] = self.reviewed_by_user_id
+        d["reviewed_at"] = self.reviewed_at.isoformat() if self.reviewed_at else None
+        d["execution_timeout"] = self.execution_timeout
+        d["memory_limit"] = self.memory_limit
+        return d
+
+    @classmethod
+    def get_for_user(cls, session, user_id):
+        return session.query(cls).filter_by(user_id=user_id).order_by(cls.created_at.desc()).all()
+
+    @classmethod
+    def get_by_name(cls, session, name):
+        return session.query(cls).filter_by(name=name).first()
+
+    @classmethod
+    def search(
+        cls,
+        session,
+        category=None,
+        group=None,
+        plugin_type=None,
+        min_rating=None,
+        status=None,
+        query=None,
+        limit=50,
+        offset=0,
+    ):
+        q = session.query(cls)
+        if status:
+            q = q.filter(cls.approval_status == status)
+        if category:
+            q = q.filter(cls.category == category)
+        if group:
+            q = q.filter(cls.group == group)
+        if plugin_type:
+            q = q.filter(cls.type == plugin_type)
+        if min_rating is not None:
+            q = q.filter(cls.rating >= min_rating)
+        if query:
+            like = "%{}%".format(query)
+            q = q.filter(cls.name.ilike(like) | cls.description.ilike(like) | cls.author.ilike(like))
+        total = q.count()
+        plugins = q.order_by(cls.rating.desc(), cls.created_at.desc()).offset(offset).limit(limit).all()
+        return plugins, total

--- a/tests/test_db_upgrade.py
+++ b/tests/test_db_upgrade.py
@@ -1,5 +1,8 @@
-"""Tests for the startup schema upgrader (in-memory SQLite)."""
+"""Tests for the startup schema upgrader."""
 
+import os
+
+import pytest
 from sqlalchemy import create_engine, inspect, text
 
 # Importing these models registers them on the shared metadata so
@@ -8,9 +11,21 @@ from sqlalchemy import create_engine, inspect, text
 import owtf.models.email_confirmation  # noqa: F401
 import owtf.models.user  # noqa: F401
 import owtf.models.user_login_token  # noqa: F401
+from owtf.db import upgrade as upgrade_module
 from owtf.db.upgrade import run_startup_upgrades
 from owtf.models.user import User
 from owtf.models.user_plugin import UserPlugin
+
+POSTGRES_URL = os.environ.get("TEST_POSTGRES_URL")
+
+
+@pytest.fixture(autouse=True)
+def _reset_upgrade_guard():
+    # The upgrader runs at most once per process. Reset the guard so
+    # each test starts from a clean state.
+    upgrade_module._UPGRADES_APPLIED = False
+    yield
+    upgrade_module._UPGRADES_APPLIED = False
 
 
 def _column_names(engine, table):
@@ -153,3 +168,137 @@ def test_users_upgrade_is_idempotent():
 
     cols = _column_names(engine, "users")
     assert "is_admin" in cols
+
+
+def test_run_startup_upgrades_is_a_no_op_after_first_call():
+    """The module-level guard blocks a second inspection pass in the same process."""
+    engine = create_engine("sqlite:///:memory:")
+    UserPlugin.metadata.create_all(engine, tables=[User.__table__, UserPlugin.__table__])
+
+    run_startup_upgrades(engine)
+    assert upgrade_module._UPGRADES_APPLIED is True
+
+    # Second call should skip: point the inspector at a broken engine to
+    # prove the code path never runs.
+    run_startup_upgrades("not-an-engine")
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL coverage. Skipped unless TEST_POSTGRES_URL is set, e.g.
+# TEST_POSTGRES_URL=postgresql+psycopg2://user:pass@localhost:5432/owtf_test
+# ---------------------------------------------------------------------------
+
+
+postgres_only = pytest.mark.skipif(
+    not POSTGRES_URL,
+    reason="TEST_POSTGRES_URL not set; requires a running PostgreSQL instance",
+)
+
+
+def _drop_test_tables(engine):
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS user_plugins CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS users CASCADE"))
+
+
+@postgres_only
+def test_postgres_upgrade_adds_missing_columns():
+    """End-to-end upgrade on a pre-review-trail user_plugins table in PostgreSQL."""
+    engine = create_engine(POSTGRES_URL)
+    _drop_test_tables(engine)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE user_plugins (
+                        id SERIAL PRIMARY KEY,
+                        name VARCHAR(128) NOT NULL,
+                        description TEXT NOT NULL,
+                        "group" VARCHAR(32) NOT NULL,
+                        type VARCHAR(32) NOT NULL,
+                        author VARCHAR(128) NOT NULL,
+                        file_path VARCHAR(512) NOT NULL,
+                        rating FLOAT NOT NULL DEFAULT 0.0,
+                        approval_status VARCHAR(16) NOT NULL DEFAULT 'pending',
+                        user_id INTEGER,
+                        created_at TIMESTAMP NOT NULL,
+                        updated_at TIMESTAMP NOT NULL
+                    )
+                    """
+                )
+            )
+
+        run_startup_upgrades(engine)
+
+        cols = _column_names(engine, "user_plugins")
+        for expected in (
+            "rejection_reason",
+            "reviewed_by_user_id",
+            "reviewed_at",
+            "execution_timeout",
+            "memory_limit",
+            "is_public",
+            "version",
+            "tags",
+            "category",
+        ):
+            assert expected in cols
+    finally:
+        _drop_test_tables(engine)
+
+
+@postgres_only
+def test_postgres_partial_upgrade_recovers_after_duplicate_column_error():
+    """
+    Simulate the race described in _add_missing_columns: one column has
+    already been added by a parallel worker. PostgreSQL aborts a whole
+    transaction after the first DDL error, so if the loop shared a single
+    txn every later ALTER would silently fail. Per-column transactions
+    must let the remaining ALTERs succeed.
+    """
+    engine = create_engine(POSTGRES_URL)
+    _drop_test_tables(engine)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE user_plugins (
+                        id SERIAL PRIMARY KEY,
+                        name VARCHAR(128) NOT NULL,
+                        description TEXT NOT NULL,
+                        "group" VARCHAR(32) NOT NULL,
+                        type VARCHAR(32) NOT NULL,
+                        author VARCHAR(128) NOT NULL,
+                        file_path VARCHAR(512) NOT NULL,
+                        rating FLOAT NOT NULL DEFAULT 0.0,
+                        approval_status VARCHAR(16) NOT NULL DEFAULT 'pending',
+                        user_id INTEGER,
+                        created_at TIMESTAMP NOT NULL,
+                        updated_at TIMESTAMP NOT NULL,
+                        rejection_reason TEXT
+                    )
+                    """
+                )
+            )
+
+        # rejection_reason already exists; the upgrader will hit a
+        # duplicate-column error on that ALTER but must still add every
+        # other missing column.
+        run_startup_upgrades(engine)
+
+        cols = _column_names(engine, "user_plugins")
+        for expected in (
+            "reviewed_by_user_id",
+            "reviewed_at",
+            "execution_timeout",
+            "memory_limit",
+            "is_public",
+            "version",
+            "tags",
+            "category",
+        ):
+            assert expected in cols, "expected column {} to be present after upgrade".format(expected)
+    finally:
+        _drop_test_tables(engine)

--- a/tests/test_db_upgrade.py
+++ b/tests/test_db_upgrade.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import OperationalError
 
 # Importing these models registers them on the shared metadata so
 # create_all(tables=[...]) can resolve their foreign keys without
@@ -181,6 +182,110 @@ def test_run_startup_upgrades_is_a_no_op_after_first_call():
     # Second call should skip: point the inspector at a broken engine to
     # prove the code path never runs.
     run_startup_upgrades("not-an-engine")
+
+
+def test_guard_stays_unset_when_upgrade_fails(monkeypatch):
+    """A DDL failure must leave the guard False so the next start retries."""
+    engine = create_engine("sqlite:///:memory:")
+    UserPlugin.metadata.create_all(engine, tables=[User.__table__, UserPlugin.__table__])
+
+    # Force a real (non-duplicate-column) DBAPI failure on every ALTER.
+    def _boom(engine_arg, table_name, upgrades):
+        raise OperationalError("ALTER TABLE ...", {}, Exception("disk full"))
+
+    monkeypatch.setattr(upgrade_module, "_add_missing_columns", _boom)
+
+    with pytest.raises(OperationalError):
+        run_startup_upgrades(engine)
+
+    assert upgrade_module._UPGRADES_APPLIED is False, (
+        "guard must stay False after a failed upgrade so the next start retries"
+    )
+
+
+def test_non_duplicate_ddl_error_is_raised():
+    """Only duplicate-column races are swallowed; every other error stops startup."""
+    engine = create_engine("sqlite:///:memory:")
+
+    # Create user_plugins with a broken column definition so the first
+    # ALTER hits a genuine SQL error rather than a duplicate-column race.
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE user_plugins (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name VARCHAR(128) NOT NULL
+                )
+                """
+            )
+        )
+
+    # Point the upgrader at a bogus DDL fragment. SQLite raises
+    # OperationalError("near ...: syntax error"), which is not a
+    # duplicate-column race and must propagate.
+    monkeypatch_upgrades = [("garbage_col", "NOT A REAL TYPE ((")]
+    original = upgrade_module._USER_PLUGIN_COLUMN_UPGRADES
+    upgrade_module._USER_PLUGIN_COLUMN_UPGRADES = monkeypatch_upgrades
+    try:
+        with pytest.raises(OperationalError):
+            run_startup_upgrades(engine)
+    finally:
+        upgrade_module._USER_PLUGIN_COLUMN_UPGRADES = original
+
+    assert upgrade_module._UPGRADES_APPLIED is False
+
+
+def test_duplicate_column_race_is_swallowed_and_other_columns_added():
+    """A duplicate-column error on one ALTER must not stop the rest of the batch."""
+    engine = create_engine("sqlite:///:memory:")
+
+    # Legacy table plus rejection_reason already added by a hypothetical
+    # sibling worker. The upgrader will hit "duplicate column" on
+    # rejection_reason and must continue with the remaining columns.
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE user_plugins (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name VARCHAR(128) NOT NULL,
+                    rejection_reason TEXT
+                )
+                """
+            )
+        )
+
+    # Rebuild _existing_columns behaviour to omit rejection_reason so
+    # the upgrader tries to add it again, triggering the race path.
+    original_existing = upgrade_module._existing_columns
+
+    def _pretend_rejection_reason_missing(engine_arg, table_name):
+        cols = original_existing(engine_arg, table_name)
+        cols.discard("rejection_reason")
+        return cols
+
+    upgrade_module._existing_columns = _pretend_rejection_reason_missing
+    try:
+        run_startup_upgrades(engine)
+    finally:
+        upgrade_module._existing_columns = original_existing
+
+    cols = _column_names(engine, "user_plugins")
+    # The rest of the batch still landed.
+    for expected in (
+        "reviewed_by_user_id",
+        "reviewed_at",
+        "execution_timeout",
+        "memory_limit",
+        "is_public",
+        "version",
+        "tags",
+        "category",
+    ):
+        assert expected in cols
+    # Guard is set because the run succeeded end to end.
+    assert upgrade_module._UPGRADES_APPLIED is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_db_upgrade.py
+++ b/tests/test_db_upgrade.py
@@ -1,0 +1,155 @@
+"""Tests for the startup schema upgrader (in-memory SQLite)."""
+
+from sqlalchemy import create_engine, inspect, text
+
+# Importing these models registers them on the shared metadata so
+# create_all(tables=[...]) can resolve their foreign keys without
+# pulling in unrelated tables.
+import owtf.models.email_confirmation  # noqa: F401
+import owtf.models.user  # noqa: F401
+import owtf.models.user_login_token  # noqa: F401
+from owtf.db.upgrade import run_startup_upgrades
+from owtf.models.user import User
+from owtf.models.user_plugin import UserPlugin
+
+
+def _column_names(engine, table):
+    return {c["name"] for c in inspect(engine).get_columns(table)}
+
+
+def test_fresh_install_is_a_no_op():
+    engine = create_engine("sqlite:///:memory:")
+    UserPlugin.metadata.create_all(engine, tables=[User.__table__, UserPlugin.__table__])
+    before = _column_names(engine, "user_plugins")
+
+    run_startup_upgrades(engine)
+
+    after = _column_names(engine, "user_plugins")
+    assert before == after
+    # Sanity check that the fresh install already carries the review
+    # trail columns.
+    assert "rejection_reason" in after
+    assert "reviewed_by_user_id" in after
+    assert "execution_timeout" in after
+
+
+def test_upgrade_adds_missing_review_columns():
+    """Legacy user_plugins table (pre review-trail) should gain the new columns."""
+    engine = create_engine("sqlite:///:memory:")
+
+    # Build a legacy user_plugins table by hand, without any of the
+    # columns that were added later.
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE user_plugins (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name VARCHAR(128) NOT NULL,
+                    description TEXT NOT NULL,
+                    "group" VARCHAR(32) NOT NULL,
+                    type VARCHAR(32) NOT NULL,
+                    author VARCHAR(128) NOT NULL,
+                    file_path VARCHAR(512) NOT NULL,
+                    rating FLOAT NOT NULL DEFAULT 0.0,
+                    approval_status VARCHAR(16) NOT NULL DEFAULT 'pending',
+                    user_id INTEGER,
+                    created_at TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+
+    before = _column_names(engine, "user_plugins")
+    assert "rejection_reason" not in before
+    assert "reviewed_by_user_id" not in before
+
+    run_startup_upgrades(engine)
+
+    after = _column_names(engine, "user_plugins")
+    # Every column the schema upgrader knows about is now present.
+    for expected in (
+        "rejection_reason",
+        "reviewed_by_user_id",
+        "reviewed_at",
+        "execution_timeout",
+        "memory_limit",
+        "is_public",
+        "version",
+        "tags",
+        "category",
+    ):
+        assert expected in after, "expected column {} to be present after upgrade".format(expected)
+
+
+def test_upgrader_is_idempotent():
+    engine = create_engine("sqlite:///:memory:")
+    UserPlugin.metadata.create_all(engine, tables=[User.__table__, UserPlugin.__table__])
+
+    run_startup_upgrades(engine)
+    run_startup_upgrades(engine)
+
+    cols = _column_names(engine, "user_plugins")
+    assert "rejection_reason" in cols
+
+
+def test_missing_table_is_ignored():
+    """Upgrader must skip silently if the table has not been created yet."""
+    engine = create_engine("sqlite:///:memory:")
+    run_startup_upgrades(engine)
+
+
+def test_upgrade_adds_is_admin_to_existing_users_table():
+    """Pre-marketplace users table must gain is_admin so User queries don't raise."""
+    engine = create_engine("sqlite:///:memory:")
+
+    # Hand-build a pre-marketplace users table (no is_admin, no
+    # user_plugins yet). Matches the schema an existing install would
+    # have on disk before pulling this branch.
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name VARCHAR(255) NOT NULL UNIQUE,
+                    email VARCHAR(255) NOT NULL UNIQUE,
+                    password VARCHAR(255) NOT NULL,
+                    is_active BOOLEAN,
+                    otp_secret_key VARCHAR(255) NOT NULL UNIQUE
+                )
+                """
+            )
+        )
+
+    before = _column_names(engine, "users")
+    assert "is_admin" not in before
+
+    run_startup_upgrades(engine)
+
+    after = _column_names(engine, "users")
+    assert "is_admin" in after
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users (name, email, password, is_active, otp_secret_key) "
+                "VALUES ('alice', 'a@example.com', 'x', 1, 'k1')"
+            )
+        )
+        row = conn.execute(text("SELECT is_admin FROM users WHERE name='alice'")).fetchone()
+    assert row is not None
+    # SQLite stores BOOLEAN as 0/1.
+    assert row[0] in (0, False)
+
+
+def test_users_upgrade_is_idempotent():
+    engine = create_engine("sqlite:///:memory:")
+    UserPlugin.metadata.create_all(engine, tables=[User.__table__, UserPlugin.__table__])
+
+    run_startup_upgrades(engine)
+    run_startup_upgrades(engine)
+
+    cols = _column_names(engine, "users")
+    assert "is_admin" in cols

--- a/tests/unit/managers/test_worker.py
+++ b/tests/unit/managers/test_worker.py
@@ -8,10 +8,15 @@ from sqlalchemy.orm import sessionmaker
 
 from owtf.db.model_base import Model
 from owtf.lib.exceptions import InvalidParameterType
+from owtf.models.command import Command  # noqa: F401 - register Target relationship
+from owtf.models.grep_output import GrepOutput  # noqa: F401 - register Transaction relationship
 from owtf.models.plugin import Plugin
+from owtf.models.plugin_output import PluginOutput  # noqa: F401 - register Plugin relationship
 from owtf.models.session import Session  # noqa: F401 - register association-table foreign keys
 from owtf.models.target import Target
 from owtf.models.test_group import TestGroup as _TestGroup
+from owtf.models.transaction import Transaction  # noqa: F401 - register Target relationship
+from owtf.models.url import Url  # noqa: F401 - register Target relationship
 from owtf.models.work import Work
 from owtf.settings import WORKER_BATCH_SIZE, WORKER_HIGH_WATER, WORKER_LOW_WATER, WORKER_MAX_PROCESSES
 


### PR DESCRIPTION
## Description

  Foundation for the Community Plugin Marketplace series. First of six smaller PRs that together replace the giant #1444.

  This PR only touches the data layer:

  - New `UserPlugin` SQLAlchemy model backing a new `user_plugins` table. Holds the metadata for community-uploaded plugins (name, description, group, type, author, approval status, reviewer trail, resource
  limits, tags).
  - New `is_admin` column on the `users` table. The role is not enforced anywhere in this PR; that lands in the admin auth PR (next one in the series).
  - New `owtf.db.upgrade.run_startup_upgrades`. Runs `ALTER TABLE ADD COLUMN` for any column the ORM expects that a live table does not have. Idempotent, safe on every boot. Wired into `get_db_engine` right after
   `create_all`.
   
  No API endpoints, no handlers, no runner changes, no UI, no docs. Those follow in the next PRs so each one stays reviewable.
  
  ## Related Issue
  
  Splits the data layer out of #1444. Same underlying feature series, just smaller.
  
  ## Motivation and Context
  
  PR #1444 was too large for a comfortable review. As agreed with @viyatb, the plan is to break the marketplace into ~6 focused PRs so each piece can be reviewed on its own without holding up the rest.
  
  The DB upgrader exists because OWTF does not use Alembic. `create_all` builds missing tables but never adds missing columns to an existing one, so an operator upgrading an install would otherwise hit
  `UndefinedColumn` on the first query. The upgrader closes that gap without pulling in a full migration framework.
  
  ## Reviewers

  @viyatb @7a

  ## How Has This Been Tested?

  Local, Python 3.13, in-memory SQLite (no PostgreSQL needed).

  pytest tests/test_db_upgrade.py -q

  Result: 6 passed.

  Covers:

  - Fresh install: upgrader runs against an already up-to-date schema and does nothing.
  - Legacy `user_plugins` table (pre review-trail columns): upgrader adds every missing column.
  - Legacy `users` table (pre-marketplace, no `is_admin`): upgrader adds `is_admin` so any User query keeps working.
  - Idempotency: two consecutive `run_startup_upgrades` calls are a no-op the second time.
  - Missing table: upgrader silently skips instead of crashing.

  ## Screenshots (if appropriate):

  Not applicable, no UI in this PR.

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Other

  ### Checklist:

  - [x] My code follows the code style (modified PEP8) of this project.
  - [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.