### PR TITLE
Community Plugin Marketplace: AST validator for uploads

### DIFF
--- a/owtf/plugin/validator.py
+++ b/owtf/plugin/validator.py
@@ -87,6 +87,16 @@ BLOCKED_ATTR_CALLS = frozenset(
 
 WRITE_MODES = frozenset({"w", "wb", "a", "ab", "x", "xb", "w+", "wb+", "a+", "ab+", "r+", "rb+"})
 
+SUBPROCESS_SHELL_CALLS = frozenset(
+    {
+        "subprocess.Popen",
+        "subprocess.run",
+        "subprocess.call",
+        "subprocess.check_call",
+        "subprocess.check_output",
+    }
+)
+
 
 @dataclass
 class ValidationResult:
@@ -106,16 +116,54 @@ class ValidationResult:
         return "\n".join(lines)
 
 
+def _check_module_contract(tree):
+    """Enforce top-level DESCRIPTION string and top-level run() entry point."""
+    violations = []
+    warnings = []
+    has_description = False
+    has_run = False
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if not (isinstance(target, ast.Name) and target.id == "DESCRIPTION"):
+                    continue
+                if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                    has_description = True
+                else:
+                    violations.append("Line {}: DESCRIPTION must be a string literal".format(node.lineno))
+        elif isinstance(node, ast.FunctionDef) and node.name == "run":
+            has_run = True
+            args = node.args
+            if len(args.args) + len(args.posonlyargs) == 0:
+                warnings.append(
+                    "Line {}: function 'run' has no parameters. Community plugins "
+                    "should accept 'PluginInfo' (the OWTF plugin dict).".format(node.lineno)
+                )
+
+    if not has_description:
+        violations.append("Missing required module-level string constant: DESCRIPTION")
+    if not has_run:
+        violations.append(
+            "Missing required top-level function: run(PluginInfo). "
+            "This is the plugin entry point and must accept the OWTF plugin dict."
+        )
+    return violations, warnings
+
+
 class _SecurityVisitor(ast.NodeVisitor):
     def __init__(self, filename="<unknown>"):
         self.filename = filename
         self.violations = []
         self.warnings = []
-        self._has_run_func = False
-        self._has_description = False
+        # local name -> dotted origin, e.g. "sp" -> "subprocess",
+        # "process" -> "subprocess.run".
+        self.aliases = {}
 
     def visit_Import(self, node):
         for alias in node.names:
+            local = alias.asname or alias.name.split(".")[0]
+            self.aliases[local] = alias.name
             root = alias.name.split(".")[0]
             if root in BLOCKED_IMPORTS:
                 self.violations.append("Line {}: blocked import '{}'".format(node.lineno, alias.name))
@@ -126,28 +174,42 @@ class _SecurityVisitor(ast.NodeVisitor):
         root = module.split(".")[0]
         if root in BLOCKED_IMPORTS:
             self.violations.append("Line {}: blocked import 'from {} import ...'".format(node.lineno, module))
+        for alias in node.names:
+            local = alias.asname or alias.name
+            self.aliases[local] = "{}.{}".format(module, alias.name) if module else alias.name
         self.generic_visit(node)
+
+    def _resolve(self, func):
+        """Return the dotted origin for a Call.func node, following import aliases."""
+        if isinstance(func, ast.Name):
+            return self.aliases.get(func.id, func.id)
+        if isinstance(func, ast.Attribute):
+            parts = [func.attr]
+            cur = func.value
+            while isinstance(cur, ast.Attribute):
+                parts.append(cur.attr)
+                cur = cur.value
+            if isinstance(cur, ast.Name):
+                parts.append(self.aliases.get(cur.id, cur.id))
+                return ".".join(reversed(parts))
+        return None
 
     def visit_Call(self, node):
         func = node.func
+        qualified = self._resolve(func)
 
         if isinstance(func, ast.Name) and func.id in BLOCKED_BUILTINS:
             self.violations.append("Line {}: blocked built-in call '{}()'".format(node.lineno, func.id))
 
-        elif isinstance(func, ast.Attribute):
-            try:
-                full = ast.unparse(func)
-            except AttributeError:
-                full = ""
-            if full in BLOCKED_ATTR_CALLS:
-                self.violations.append("Line {}: blocked call '{}()'".format(node.lineno, full))
+        if qualified in BLOCKED_ATTR_CALLS:
+            self.violations.append("Line {}: blocked call '{}()'".format(node.lineno, qualified))
 
-            if func.attr in ("Popen", "run", "call", "check_call", "check_output"):
-                for kw in node.keywords:
-                    if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
-                        self.violations.append(
-                            "Line {}: subprocess called with shell=True (use a list of args)".format(node.lineno)
-                        )
+        if qualified in SUBPROCESS_SHELL_CALLS:
+            for kw in node.keywords:
+                if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                    self.violations.append(
+                        "Line {}: subprocess called with shell=True (use a list of args)".format(node.lineno)
+                    )
 
         if isinstance(func, ast.Name) and func.id == "open":
             self._check_open_mode(node)
@@ -169,23 +231,6 @@ class _SecurityVisitor(ast.NodeVisitor):
                 )
             )
 
-    def visit_Assign(self, node):
-        for target in node.targets:
-            if isinstance(target, ast.Name) and target.id == "DESCRIPTION":
-                self._has_description = True
-        self.generic_visit(node)
-
-    def visit_FunctionDef(self, node):
-        if node.name == "run":
-            self._has_run_func = True
-            args = node.args
-            if len(args.args) + len(args.posonlyargs) == 0:
-                self.warnings.append(
-                    "Line {}: function 'run' has no parameters. Community plugins "
-                    "should accept 'PluginInfo' (the OWTF plugin dict).".format(node.lineno)
-                )
-        self.generic_visit(node)
-
     def visit_AsyncFunctionDef(self, node):
         self.violations.append("Line {}: async functions are not permitted in community plugins".format(node.lineno))
         self.generic_visit(node)
@@ -198,15 +243,6 @@ class _SecurityVisitor(ast.NodeVisitor):
                 )
             )
         self.generic_visit(node)
-
-    def finalize(self):
-        if not self._has_description:
-            self.violations.append("Missing required module-level constant: DESCRIPTION (string)")
-        if not self._has_run_func:
-            self.violations.append(
-                "Missing required function: run(PluginInfo). "
-                "This is the plugin entry point and must accept the OWTF plugin dict."
-            )
 
 
 class PluginValidator:
@@ -222,15 +258,14 @@ class PluginValidator:
                 violations=["SyntaxError at line {}: {}".format(exc.lineno, exc.msg)],
             )
 
+        contract_violations, contract_warnings = _check_module_contract(tree)
+
         visitor = _SecurityVisitor(filename=filename)
         visitor.visit(tree)
-        visitor.finalize()
 
-        return ValidationResult(
-            passed=len(visitor.violations) == 0,
-            violations=visitor.violations,
-            warnings=visitor.warnings,
-        )
+        violations = contract_violations + visitor.violations
+        warnings = contract_warnings + visitor.warnings
+        return ValidationResult(passed=not violations, violations=violations, warnings=warnings)
 
     @staticmethod
     def validate_file(path):

--- a/owtf/plugin/validator.py
+++ b/owtf/plugin/validator.py
@@ -179,6 +179,18 @@ class _SecurityVisitor(ast.NodeVisitor):
             self.aliases[local] = "{}.{}".format(module, alias.name) if module else alias.name
         self.generic_visit(node)
 
+    def visit_Assign(self, node):
+        # Follow simple `x = subprocess.run` (and similar) aliases so a
+        # later `x("id", shell=True)` call still resolves to the underlying
+        # dotted name and gets caught by the existing dispatcher. Only
+        # single-target Name assignments; anything more complex falls
+        # through and is left to visit_Call.
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            origin = self._resolve(node.value)
+            if origin:
+                self.aliases[node.targets[0].id] = origin
+        self.generic_visit(node)
+
     def _resolve(self, func):
         """Return the dotted origin for a Call.func node, following import aliases."""
         if isinstance(func, ast.Name):
@@ -206,10 +218,21 @@ class _SecurityVisitor(ast.NodeVisitor):
 
         if qualified in SUBPROCESS_SHELL_CALLS:
             for kw in node.keywords:
-                if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
-                    self.violations.append(
-                        "Line {}: subprocess called with shell=True (use a list of args)".format(node.lineno)
-                    )
+                if kw.arg != "shell":
+                    continue
+                # Only a literal shell=False is safe. Literal True, a
+                # variable, or any other expression must be flagged so
+                # authors cannot smuggle shell=True past the validator
+                # by aliasing the flag through a local name.
+                if isinstance(kw.value, ast.Constant) and kw.value.value is False:
+                    continue
+                if isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                    detail = "shell=True"
+                else:
+                    detail = "shell=<non-literal-False value>"
+                self.violations.append(
+                    "Line {}: subprocess called with {} (use a list of args or shell=False)".format(node.lineno, detail)
+                )
 
         if isinstance(func, ast.Name) and func.id == "open":
             self._check_open_mode(node)

--- a/owtf/plugin/validator.py
+++ b/owtf/plugin/validator.py
@@ -1,0 +1,250 @@
+"""
+owtf.plugin.validator
+~~~~~~~~~~~~~~~~~~~~~
+
+AST-based static analysis for community plugin uploads. Rejects obvious
+misuse (dangerous imports, eval/exec, os.system, shell=True, write-mode
+open) before the file is written to disk. Not a sandbox: admin review of
+the source is the actual trust boundary. This just keeps the review
+queue clean.
+
+Every community plugin must declare a module-level ``DESCRIPTION``
+string and a top-level ``run(PluginInfo)`` function, matching the
+built-in OWTF plugin contract.
+"""
+
+import ast
+from dataclasses import dataclass, field
+from typing import List
+
+BLOCKED_IMPORTS = frozenset(
+    {
+        "os",
+        "sys",
+        "socket",
+        "importlib",
+        "shutil",
+        "ctypes",
+        "multiprocessing",
+        "threading",
+        "signal",
+        "resource",
+        "pickle",
+        "shelve",
+        "marshal",
+        "pty",
+        "termios",
+        "tty",
+        "fcntl",
+        "builtins",
+        "gc",
+        "inspect",
+        "_thread",
+        "code",
+        "codeop",
+    }
+)
+
+BLOCKED_BUILTINS = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "__import__",
+        "execfile",
+        "input",
+        "breakpoint",
+    }
+)
+
+BLOCKED_ATTR_CALLS = frozenset(
+    {
+        "os.system",
+        "os.popen",
+        "os.execv",
+        "os.execve",
+        "os.execvp",
+        "os.execvpe",
+        "os.exec",
+        "os.fork",
+        "os.forkpty",
+        "os.kill",
+        "os.killpg",
+        "os.remove",
+        "os.unlink",
+        "os.rmdir",
+        "os.removedirs",
+        "os.chmod",
+        "os.chown",
+        "os.chroot",
+        "os.setuid",
+        "os.setgid",
+        "socket.socket",
+        "socket.create_connection",
+        "socket.create_server",
+    }
+)
+
+WRITE_MODES = frozenset({"w", "wb", "a", "ab", "x", "xb", "w+", "wb+", "a+", "ab+", "r+", "rb+"})
+
+
+@dataclass
+class ValidationResult:
+    passed: bool
+    violations: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def __str__(self):
+        if self.passed:
+            msg = "PASSED: No violations found."
+            if self.warnings:
+                msg += "\nWarnings:\n" + "\n".join("  - " + w for w in self.warnings)
+            return msg
+        lines = ["FAILED:"] + ["  - " + v for v in self.violations]
+        if self.warnings:
+            lines += ["Warnings:"] + ["  - " + w for w in self.warnings]
+        return "\n".join(lines)
+
+
+class _SecurityVisitor(ast.NodeVisitor):
+    def __init__(self, filename="<unknown>"):
+        self.filename = filename
+        self.violations = []
+        self.warnings = []
+        self._has_run_func = False
+        self._has_description = False
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            root = alias.name.split(".")[0]
+            if root in BLOCKED_IMPORTS:
+                self.violations.append("Line {}: blocked import '{}'".format(node.lineno, alias.name))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        module = node.module or ""
+        root = module.split(".")[0]
+        if root in BLOCKED_IMPORTS:
+            self.violations.append("Line {}: blocked import 'from {} import ...'".format(node.lineno, module))
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        func = node.func
+
+        if isinstance(func, ast.Name) and func.id in BLOCKED_BUILTINS:
+            self.violations.append("Line {}: blocked built-in call '{}()'".format(node.lineno, func.id))
+
+        elif isinstance(func, ast.Attribute):
+            try:
+                full = ast.unparse(func)
+            except AttributeError:
+                full = ""
+            if full in BLOCKED_ATTR_CALLS:
+                self.violations.append("Line {}: blocked call '{}()'".format(node.lineno, full))
+
+            if func.attr in ("Popen", "run", "call", "check_call", "check_output"):
+                for kw in node.keywords:
+                    if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                        self.violations.append(
+                            "Line {}: subprocess called with shell=True (use a list of args)".format(node.lineno)
+                        )
+
+        if isinstance(func, ast.Name) and func.id == "open":
+            self._check_open_mode(node)
+
+        self.generic_visit(node)
+
+    def _check_open_mode(self, node):
+        for kw in node.keywords:
+            if kw.arg == "mode" and isinstance(kw.value, ast.Constant) and kw.value.value in WRITE_MODES:
+                self.violations.append(
+                    "Line {}: open() called with write/append mode '{}' (read-only access permitted)".format(
+                        node.lineno, kw.value.value
+                    )
+                )
+        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) and node.args[1].value in WRITE_MODES:
+            self.violations.append(
+                "Line {}: open() called with write/append mode '{}' (read-only access permitted)".format(
+                    node.lineno, node.args[1].value
+                )
+            )
+
+    def visit_Assign(self, node):
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "DESCRIPTION":
+                self._has_description = True
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        if node.name == "run":
+            self._has_run_func = True
+            args = node.args
+            if len(args.args) + len(args.posonlyargs) == 0:
+                self.warnings.append(
+                    "Line {}: function 'run' has no parameters. Community plugins "
+                    "should accept 'PluginInfo' (the OWTF plugin dict).".format(node.lineno)
+                )
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node):
+        self.violations.append("Line {}: async functions are not permitted in community plugins".format(node.lineno))
+        self.generic_visit(node)
+
+    def visit_While(self, node):
+        if isinstance(node.test, ast.Constant) and node.test.value is True:
+            self.warnings.append(
+                "Line {}: unconditional while True loop detected; ensure plugin has a break condition".format(
+                    node.lineno
+                )
+            )
+        self.generic_visit(node)
+
+    def finalize(self):
+        if not self._has_description:
+            self.violations.append("Missing required module-level constant: DESCRIPTION (string)")
+        if not self._has_run_func:
+            self.violations.append(
+                "Missing required function: run(PluginInfo). "
+                "This is the plugin entry point and must accept the OWTF plugin dict."
+            )
+
+
+class PluginValidator:
+    """Validate a community plugin's source without executing it."""
+
+    @staticmethod
+    def validate_source(source, filename="<unknown>"):
+        try:
+            tree = ast.parse(source, filename=filename)
+        except SyntaxError as exc:
+            return ValidationResult(
+                passed=False,
+                violations=["SyntaxError at line {}: {}".format(exc.lineno, exc.msg)],
+            )
+
+        visitor = _SecurityVisitor(filename=filename)
+        visitor.visit(tree)
+        visitor.finalize()
+
+        return ValidationResult(
+            passed=len(visitor.violations) == 0,
+            violations=visitor.violations,
+            warnings=visitor.warnings,
+        )
+
+    @staticmethod
+    def validate_file(path):
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                source = fh.read()
+        except OSError as exc:
+            return ValidationResult(passed=False, violations=["Cannot read file: {}".format(exc)])
+        return PluginValidator.validate_source(source, filename=path)
+
+    @staticmethod
+    def validate_bytes(data, filename="<upload>"):
+        try:
+            source = data.decode("utf-8", errors="replace")
+        except Exception as exc:
+            return ValidationResult(passed=False, violations=["Cannot decode plugin bytes: {}".format(exc)])
+        return PluginValidator.validate_source(source, filename=filename)

--- a/owtf/plugin/validator.py
+++ b/owtf/plugin/validator.py
@@ -85,7 +85,7 @@ BLOCKED_ATTR_CALLS = frozenset(
     }
 )
 
-WRITE_MODES = frozenset({"w", "wb", "a", "ab", "x", "xb", "w+", "wb+", "a+", "ab+", "r+", "rb+"})
+READ_ONLY_MODES = frozenset({"r", "rt", "tr", "rb", "br"})
 
 SUBPROCESS_SHELL_CALLS = frozenset(
     {
@@ -135,10 +135,14 @@ def _check_module_contract(tree):
         elif isinstance(node, ast.FunctionDef) and node.name == "run":
             has_run = True
             args = node.args
-            if len(args.args) + len(args.posonlyargs) == 0:
-                warnings.append(
-                    "Line {}: function 'run' has no parameters. Community plugins "
-                    "should accept 'PluginInfo' (the OWTF plugin dict).".format(node.lineno)
+            positional = args.posonlyargs + args.args
+            required_positional = len(positional) - len(args.defaults)
+            required_keyword_only = sum(default is None for default in args.kw_defaults)
+            accepts_one_argument = required_positional <= 1 and (positional or args.vararg)
+            if not accepts_one_argument or required_keyword_only:
+                violations.append(
+                    "Line {}: function 'run' must be callable with exactly one positional argument "
+                    "(the OWTF PluginInfo dict)".format(node.lineno)
                 )
 
     if not has_description:
@@ -210,8 +214,8 @@ class _SecurityVisitor(ast.NodeVisitor):
         func = node.func
         qualified = self._resolve(func)
 
-        if isinstance(func, ast.Name) and func.id in BLOCKED_BUILTINS:
-            self.violations.append("Line {}: blocked built-in call '{}()'".format(node.lineno, func.id))
+        if qualified in BLOCKED_BUILTINS:
+            self.violations.append("Line {}: blocked built-in call '{}()'".format(node.lineno, qualified))
 
         if qualified in BLOCKED_ATTR_CALLS:
             self.violations.append("Line {}: blocked call '{}()'".format(node.lineno, qualified))
@@ -234,25 +238,33 @@ class _SecurityVisitor(ast.NodeVisitor):
                     "Line {}: subprocess called with {} (use a list of args or shell=False)".format(node.lineno, detail)
                 )
 
-        if isinstance(func, ast.Name) and func.id == "open":
+        if qualified == "open":
             self._check_open_mode(node)
 
         self.generic_visit(node)
 
     def _check_open_mode(self, node):
+        mode_node = node.args[1] if len(node.args) >= 2 else None
         for kw in node.keywords:
-            if kw.arg == "mode" and isinstance(kw.value, ast.Constant) and kw.value.value in WRITE_MODES:
-                self.violations.append(
-                    "Line {}: open() called with write/append mode '{}' (read-only access permitted)".format(
-                        node.lineno, kw.value.value
-                    )
-                )
-        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) and node.args[1].value in WRITE_MODES:
-            self.violations.append(
-                "Line {}: open() called with write/append mode '{}' (read-only access permitted)".format(
-                    node.lineno, node.args[1].value
-                )
+            if kw.arg == "mode":
+                mode_node = kw.value
+
+        # Omitting mode is the literal read-only default. Once a mode is
+        # supplied, only a known literal read mode is safe to accept.
+        if mode_node is None:
+            return
+        if isinstance(mode_node, ast.Constant) and mode_node.value in READ_ONLY_MODES:
+            return
+
+        if isinstance(mode_node, ast.Constant):
+            detail = repr(mode_node.value)
+        else:
+            detail = "a dynamic value"
+        self.violations.append(
+            "Line {}: open() called with {} mode (only literal read-only modes are permitted)".format(
+                node.lineno, detail
             )
+        )
 
     def visit_AsyncFunctionDef(self, node):
         self.violations.append("Line {}: async functions are not permitted in community plugins".format(node.lineno))
@@ -293,16 +305,16 @@ class PluginValidator:
     @staticmethod
     def validate_file(path):
         try:
-            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            with open(path, "r", encoding="utf-8") as fh:
                 source = fh.read()
-        except OSError as exc:
+        except (OSError, UnicodeError) as exc:
             return ValidationResult(passed=False, violations=["Cannot read file: {}".format(exc)])
         return PluginValidator.validate_source(source, filename=path)
 
     @staticmethod
     def validate_bytes(data, filename="<upload>"):
         try:
-            source = data.decode("utf-8", errors="replace")
-        except Exception as exc:
+            source = data.decode("utf-8")
+        except (AttributeError, UnicodeError) as exc:
             return ValidationResult(passed=False, violations=["Cannot decode plugin bytes: {}".format(exc)])
         return PluginValidator.validate_source(source, filename=filename)

--- a/tests/test_plugin_validator.py
+++ b/tests/test_plugin_validator.py
@@ -303,6 +303,44 @@ def run(PluginInfo):
         result = validate(source)
         assert result.passed, str(result)
 
+    def test_local_name_alias_of_subprocess_run_with_shell_true_blocked(self):
+        """`x = subprocess.run; x("id", shell=True)` must be caught same as a direct call."""
+        source = """
+import subprocess
+DESCRIPTION = "aliased local name"
+def run(PluginInfo):
+    x = subprocess.run
+    x("id", shell=True)
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("shell" in v.lower() for v in result.violations)
+
+    def test_shell_arg_via_variable_blocked(self):
+        """shell=<variable> must be flagged; only literal shell=False is accepted."""
+        source = """
+import subprocess
+DESCRIPTION = "variable shell arg"
+def run(PluginInfo):
+    flag = True
+    subprocess.run("id", shell=flag)
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("shell" in v.lower() for v in result.violations)
+
+    def test_explicit_shell_false_is_allowed(self):
+        """The one shell= value we do accept is literal False."""
+        source = """
+import subprocess
+DESCRIPTION = "explicit shell=False"
+def run(PluginInfo):
+    subprocess.run(["ls"], shell=False)
+    return {}
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+
 
 class TestModuleContract:
     def test_nested_run_does_not_satisfy_contract(self):

--- a/tests/test_plugin_validator.py
+++ b/tests/test_plugin_validator.py
@@ -199,6 +199,18 @@ def run(PluginInfo):
         result = validate(source)
         assert not result.passed
 
+    def test_open_dynamic_mode_blocked(self):
+        source = """
+DESCRIPTION = "Dynamic mode"
+def run(PluginInfo):
+    mode = PluginInfo["mode"]
+    open("/tmp/output", mode)
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("dynamic" in violation for violation in result.violations)
+
     def test_open_read_allowed(self):
         source = """
 DESCRIPTION = "Read-only file access is fine"
@@ -256,7 +268,7 @@ def run(PluginInfo):
         assert result.passed, str(result)
         assert not any("no parameters" in w for w in result.warnings)
 
-    def test_run_with_zero_args_warning_mentions_plugininfo(self):
+    def test_run_with_zero_args_is_rejected(self):
         source = """
 DESCRIPTION = "Missing plugin arg"
 
@@ -264,11 +276,55 @@ def run():
     return {}
 """
         result = validate(source)
+        assert not result.passed
+        assert any("PluginInfo" in violation for violation in result.violations)
+
+    def test_run_requiring_two_args_is_rejected(self):
+        source = """
+DESCRIPTION = "Too many required args"
+
+def run(PluginInfo, config):
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("exactly one positional argument" in violation for violation in result.violations)
+
+    def test_run_with_optional_second_arg_is_allowed(self):
+        source = """
+DESCRIPTION = "Optional config"
+
+def run(PluginInfo, config=None):
+    return {}
+"""
+        result = validate(source)
         assert result.passed, str(result)
-        assert any("PluginInfo" in w for w in result.warnings)
 
 
 class TestAliasBypass:
+    def test_aliased_eval_is_blocked(self):
+        source = """
+DESCRIPTION = "aliased eval"
+def run(PluginInfo):
+    f = eval
+    return f("1 + 1")
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("eval" in violation for violation in result.violations)
+
+    def test_aliased_open_write_is_blocked(self):
+        source = """
+DESCRIPTION = "aliased open"
+def run(PluginInfo):
+    f = open
+    f("/tmp/output", "w")
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("read-only" in violation for violation in result.violations)
+
     def test_aliased_subprocess_run_with_shell_true_blocked(self):
         source = """
 from subprocess import run as process
@@ -419,3 +475,8 @@ class TestValidateBytes:
         source = b"import os\nDESCRIPTION='x'\ndef run(t): os.system('id')"
         result = PluginValidator.validate_bytes(source)
         assert not result.passed
+
+    def test_non_utf8_bytes_fail_before_ast_validation(self):
+        result = PluginValidator.validate_bytes(b"DESCRIPTION = 'x'\n# \xff\ndef run(info): return {}")
+        assert not result.passed
+        assert any("decode" in violation.lower() for violation in result.violations)

--- a/tests/test_plugin_validator.py
+++ b/tests/test_plugin_validator.py
@@ -1,0 +1,304 @@
+"""Tests for the community plugin AST validator."""
+
+from owtf.plugin.validator import PluginValidator
+
+VALID_PLUGIN = """
+DESCRIPTION = "A safe example plugin"
+
+def run(PluginInfo):
+    import json
+    import subprocess
+    target_url = PluginInfo["target_url"]
+    result = subprocess.run(["curl", "-sI", target_url], capture_output=True, timeout=10)
+    return {"output": result.stdout.decode()}
+"""
+
+
+def validate(source):
+    return PluginValidator.validate_source(source, filename="<test>")
+
+
+class TestValidPlugins:
+    def test_minimal_valid_plugin_passes(self):
+        result = validate(VALID_PLUGIN)
+        assert result.passed, str(result)
+
+    def test_subprocess_run_without_shell_is_allowed(self):
+        source = """
+DESCRIPTION = "Nuclei test"
+
+def run(PluginInfo):
+    import subprocess
+    target_url = PluginInfo["target_url"]
+    r = subprocess.run(["nuclei", "-u", target_url, "-json"], capture_output=True)
+    return {"raw": r.stdout.decode()}
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+
+    def test_requests_import_is_allowed(self):
+        source = """
+DESCRIPTION = "HTTP checker"
+
+def run(PluginInfo):
+    import requests
+    r = requests.get(PluginInfo["target_url"], timeout=10)
+    return {"status": r.status_code}
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+
+    def test_json_and_urllib_allowed(self):
+        source = """
+import json
+import urllib.request
+
+DESCRIPTION = "Header checker"
+
+def run(PluginInfo):
+    with urllib.request.urlopen(PluginInfo["target_url"], timeout=5) as r:
+        return {"headers": dict(r.headers)}
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+
+
+class TestBlockedImports:
+    def test_os_import_blocked(self):
+        source = """
+import os
+DESCRIPTION = "Bad"
+def run(PluginInfo): return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("os" in v for v in result.violations)
+
+    def test_socket_import_blocked(self):
+        source = """
+import socket
+DESCRIPTION = "Bad"
+def run(PluginInfo): return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("socket" in v for v in result.violations)
+
+    def test_sys_import_blocked(self):
+        source = """
+import sys
+DESCRIPTION = "Bad"
+def run(PluginInfo): return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+    def test_pickle_import_blocked(self):
+        source = """
+import pickle
+DESCRIPTION = "Bad"
+def run(PluginInfo): return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+    def test_from_os_import_blocked(self):
+        source = """
+from os import system
+DESCRIPTION = "Bad"
+def run(PluginInfo): return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+    def test_threading_blocked(self):
+        source = """
+import threading
+DESCRIPTION = "Bad"
+def run(PluginInfo): return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+
+class TestBlockedCalls:
+    def test_eval_blocked(self):
+        source = """
+DESCRIPTION = "Bad"
+def run(PluginInfo):
+    return eval("1+1")
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("eval" in v for v in result.violations)
+
+    def test_exec_blocked(self):
+        source = """
+DESCRIPTION = "Bad"
+def run(PluginInfo):
+    exec("import os")
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("exec" in v for v in result.violations)
+
+    def test_compile_blocked(self):
+        source = """
+DESCRIPTION = "Bad"
+def run(PluginInfo):
+    c = compile("1+1", "<string>", "eval")
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+    def test_os_system_attr_call_blocked(self):
+        source = """
+import subprocess
+DESCRIPTION = "Bad"
+def run(PluginInfo):
+    import os
+    os.system("ls")
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+    def test_subprocess_shell_true_blocked(self):
+        source = """
+import subprocess
+DESCRIPTION = "Shell injection risk"
+def run(PluginInfo):
+    subprocess.run("curl " + PluginInfo["target_url"], shell=True)
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("shell=True" in v for v in result.violations)
+
+    def test_open_write_mode_blocked(self):
+        source = """
+DESCRIPTION = "Write attempt"
+def run(PluginInfo):
+    with open("/etc/passwd", "w") as f:
+        f.write("pwned")
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("write" in v.lower() or "mode" in v.lower() for v in result.violations)
+
+    def test_open_append_mode_blocked(self):
+        source = """
+DESCRIPTION = "Append attempt"
+def run(PluginInfo):
+    open("/tmp/evil", "ab")
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+    def test_open_read_allowed(self):
+        source = """
+DESCRIPTION = "Read-only file access is fine"
+def run(PluginInfo):
+    with open("/etc/hosts", "r") as f:
+        return {"data": f.read()}
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+
+
+class TestRequiredStructure:
+    def test_missing_description_fails(self):
+        source = """
+def run(PluginInfo):
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("DESCRIPTION" in v for v in result.violations)
+
+    def test_missing_run_function_fails(self):
+        source = """
+DESCRIPTION = "No run function"
+def something_else():
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("run" in v for v in result.violations)
+
+    def test_both_missing_fails(self):
+        source = """
+x = 1
+"""
+        result = validate(source)
+        assert not result.passed
+        assert len(result.violations) >= 2
+
+    def test_syntax_error_returns_failure(self):
+        source = "def run(:"  # broken syntax
+        result = validate(source)
+        assert not result.passed
+        assert any("SyntaxError" in v or "syntax" in v.lower() for v in result.violations)
+
+    def test_run_with_plugininfo_signature_passes_without_param_warning(self):
+        """run(PluginInfo) is the documented contract; must not warn about params."""
+        source = """
+DESCRIPTION = "Follows the OWTF plugin contract"
+
+def run(PluginInfo):
+    return {"target": PluginInfo["target_url"]}
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+        assert not any("no parameters" in w for w in result.warnings)
+
+    def test_run_with_zero_args_warning_mentions_plugininfo(self):
+        source = """
+DESCRIPTION = "Missing plugin arg"
+
+def run():
+    return {}
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+        assert any("PluginInfo" in w for w in result.warnings)
+
+
+class TestAsyncFunctions:
+    def test_async_function_blocked(self):
+        source = """
+DESCRIPTION = "Async plugin"
+async def run(PluginInfo):
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("async" in v.lower() for v in result.violations)
+
+
+class TestValidateFile:
+    def test_file_not_found(self, tmp_path):
+        result = PluginValidator.validate_file(str(tmp_path / "nonexistent.py"))
+        assert not result.passed
+        assert any("Cannot read" in v or "No such" in v for v in result.violations)
+
+    def test_valid_file_passes(self, tmp_path):
+        p = tmp_path / "ok.py"
+        p.write_text(VALID_PLUGIN)
+        result = PluginValidator.validate_file(str(p))
+        assert result.passed, str(result)
+
+
+class TestValidateBytes:
+    def test_valid_bytes_passes(self):
+        result = PluginValidator.validate_bytes(VALID_PLUGIN.encode("utf-8"))
+        assert result.passed, str(result)
+
+    def test_invalid_bytes_fails(self):
+        source = b"import os\nDESCRIPTION='x'\ndef run(t): os.system('id')"
+        result = PluginValidator.validate_bytes(source)
+        assert not result.passed

--- a/tests/test_plugin_validator.py
+++ b/tests/test_plugin_validator.py
@@ -268,6 +268,85 @@ def run():
         assert any("PluginInfo" in w for w in result.warnings)
 
 
+class TestAliasBypass:
+    def test_aliased_subprocess_run_with_shell_true_blocked(self):
+        source = """
+from subprocess import run as process
+DESCRIPTION = "aliased shell injection"
+def run(PluginInfo):
+    process("id", shell=True)
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("shell=True" in v for v in result.violations)
+
+    def test_aliased_subprocess_module_with_shell_true_blocked(self):
+        source = """
+import subprocess as sp
+DESCRIPTION = "aliased module shell injection"
+def run(PluginInfo):
+    sp.run("id", shell=True)
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("shell=True" in v for v in result.violations)
+
+    def test_from_subprocess_import_run_without_shell_is_allowed(self):
+        source = """
+from subprocess import run
+DESCRIPTION = "safe subprocess"
+def run_wrapper():
+    run(["ls"])
+def run(PluginInfo):
+    run_wrapper()
+"""
+        result = validate(source)
+        assert result.passed, str(result)
+
+
+class TestModuleContract:
+    def test_nested_run_does_not_satisfy_contract(self):
+        source = """
+DESCRIPTION = "nested run should not count"
+def wrapper():
+    def run(PluginInfo):
+        return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("run(PluginInfo)" in v for v in result.violations)
+
+    def test_description_must_be_string_literal(self):
+        source = """
+DESCRIPTION = 42
+def run(PluginInfo):
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("DESCRIPTION" in v and "string" in v for v in result.violations)
+
+    def test_description_from_expression_rejected(self):
+        source = """
+DESCRIPTION = "a" + "b"
+def run(PluginInfo):
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+
+    def test_nested_description_does_not_satisfy_contract(self):
+        source = """
+def wrapper():
+    DESCRIPTION = "nested"
+def run(PluginInfo):
+    return {}
+"""
+        result = validate(source)
+        assert not result.passed
+        assert any("DESCRIPTION" in v for v in result.violations)
+
+
 class TestAsyncFunctions:
     def test_async_function_blocked(self):
         source = """


### PR DESCRIPTION
## Description

  Splits the AST validator out of #1444 into its own PR so it can be reviewed on its own. Independent of PR 1, no shared code.

  The validator runs at upload time, before the plugin file is written to disk, so obviously dangerous submissions are rejected instead of piling up in the admin review queue.

  What gets blocked:

  - Dangerous imports: `os`, `sys`, `socket`, `importlib`, `shutil`, `ctypes`, `multiprocessing`, `threading`, `signal`, `resource`, `pickle`, `shelve`, `marshal`, `pty`, `termios`, `tty`, `fcntl`, `builtins`,
  `gc`, `inspect`, `_thread`, `code`, `codeop`.
  - Built-ins: `eval`, `exec`, `compile`, `__import__`, `execfile`, `input`, `breakpoint`.
  - Attribute calls: `os.system`, `os.popen`, `os.exec*`, `os.fork`, `os.kill`, `os.remove`, `os.chmod`, `socket.socket`, and similar.
  - `subprocess.Popen` / `run` / `call` / `check_call` / `check_output` with `shell=True`.
  - `open(path, "w")` and every other write / append / exclusive mode. Read-mode `open()` is fine.
  - `async def` at any level.
  - Missing `DESCRIPTION` string constant or missing `run(PluginInfo)` entry point.

  What is allowed: `requests`, `subprocess.run([...])` without `shell=True`, `urllib`, `json`, and anything else that is not on the blocklist.

  This is a best-effort filter, not a sandbox. Admin review of the source before approval is the actual trust boundary; the validator just keeps the review queue clean.

  ## Related Issue

  Splits the AST validator out of #1444.

  ## Motivation and Context

  PR #1444 was too large to review comfortably. As agreed with @viyatb, the marketplace is being broken into six smaller PRs. This one is fully standalone (no manager, no handlers, no marketplace routes) so it
  can land independently of the other pieces.

  ## Reviewers

  @viyatb @7a

  ## How Has This Been Tested?

  Local, Python 3.13.

  pytest tests/test_plugin_validator.py -q

  Result: 29 passed.

  Covers:

  - Valid plugins: minimal template, `subprocess.run([...])` without shell, `requests`, `urllib`.
  - Blocked imports: `os`, `sys`, `socket`, `pickle`, `from os import ...`, `threading`.
  - Blocked calls: `eval`, `exec`, `compile`, `os.system`, `subprocess.run(shell=True)`.
  - File modes: `open(path, "w")` and `open(path, "ab")` rejected; `open(path, "r")` allowed.
  - Required structure: missing `DESCRIPTION`, missing `run`, both missing, syntax error.
  - `run(PluginInfo)` contract honoured; zero-arg `run()` warns and names the expected parameter.
  - `async def run` blocked.
  - `validate_file` and `validate_bytes` helper paths.

  ## Screenshots (if appropriate):

  Not applicable, no UI in this PR.

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Other

  ### Checklist:

  - [x] My code follows the code style (modified PEP8) of this project.
  - [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.