### PR TITLE
 Community Plugin Marketplace: admin role, JWT decorators, owtf-admin CLI

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,13 +8,12 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.backend
-    command: ["/usr/bin/wait-for-it.sh", "db:5432", "--", "/home/owtf/bin/owtf"]
+    command: ["/usr/bin/wait-for-it.sh", "db:5432", "--", "owtf"]
     environment:
       - DOCKER=1
       - POSTGRES_USER=owtf_db_user
       - POSTGRES_PASSWORD=jgZKW33Q+HZk8rqylZxaPg1lbuNGHJhgzsq3gBKV32g=
       - POSTGRES_DB=owtf_db
-      - PYTHONPATH=/home/owtf/owtf
     ports:
       - 8008:8008
       - 8010:8010

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,12 +8,13 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.backend
-    command: ["/usr/bin/wait-for-it.sh", "db:5432", "--", "owtf"]
+    command: ["/usr/bin/wait-for-it.sh", "db:5432", "--", "/home/owtf/bin/owtf"]
     environment:
       - DOCKER=1
       - POSTGRES_USER=owtf_db_user
       - POSTGRES_PASSWORD=jgZKW33Q+HZk8rqylZxaPg1lbuNGHJhgzsq3gBKV32g=
       - POSTGRES_DB=owtf_db
+      - PYTHONPATH=/home/owtf/owtf
     ports:
       - 8008:8008
       - 8010:8010

--- a/owtf/api/handlers/auth.py
+++ b/owtf/api/handlers/auth.py
@@ -3,42 +3,41 @@ owtf.api.handlers.auth
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-from sqlalchemy.sql.functions import user
-from owtf.models.user_login_token import UserLoginToken
-from owtf.api.handlers.base import APIRequestHandler
-from owtf.lib.exceptions import APIError
-from owtf.models.user import User
-from datetime import datetime, timedelta
-import bcrypt
-import json
-import jwt
+
+import logging
 import re
+import smtplib
+from datetime import datetime, timedelta
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from uuid import uuid4
+
+import bcrypt
+import jwt
+import pyotp
+from bs4 import BeautifulSoup
+
+from owtf.api.handlers.base import APIRequestHandler
+from owtf.api.handlers.jwtauth import jwtauth
+from owtf.lib.exceptions import APIError
+from owtf.models.email_confirmation import EmailConfirmation
+from owtf.models.user import User
+from owtf.models.user_login_token import UserLoginToken
 from owtf.settings import (
-    JWT_SECRET_KEY,
+    EMAIL_FROM,
+    FRONTEND_SERVER_PORT,
     JWT_ALGORITHM,
     JWT_EXP_DELTA_SECONDS,
-    is_password_valid_regex,
-    is_email_valid_regex,
-    EMAIL_FROM,
+    JWT_SECRET_KEY,
+    SERVER_ADDR,
     SMTP_HOST,
     SMTP_LOGIN,
     SMTP_PASS,
     SMTP_PORT,
-    SERVER_ADDR,
-    SERVER_PORT,
-    FRONTEND_SERVER_PORT,
+    is_email_valid_regex,
+    is_password_valid_regex,
 )
-from owtf.db.session import Session
-from uuid import uuid4
-from owtf.models.email_confirmation import EmailConfirmation
-from email.mime.text import MIMEText
-import smtplib
-from email.mime.multipart import MIMEMultipart
-import logging
-from bs4 import BeautifulSoup
 from owtf.utils.logger import OWTFLogger
-from owtf.api.handlers.jwtauth import jwtauth
-import pyotp
 
 
 class LogInHandler(APIRequestHandler):
@@ -73,7 +72,7 @@ class LogInHandler(APIRequestHandler):
             {
                 "status": "success",
                 "message": {
-                    "jwt-token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjozNSwiZXhwIjoxNjIzMjUyMjQwfQ.FjTpJySn3wprlaS26dC9LGBOMrtHJeJsTDJnyCKNmBk"
+                    "jwt-token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9....FjTpJySn3wprlaS26dC9LGBOMrtHJeJsTDJnyCKNmBk"
                 }
             }
 
@@ -109,6 +108,12 @@ class LogInHandler(APIRequestHandler):
             and bcrypt.hashpw(password.encode("utf-8"), user.password.encode("utf-8")) == user.password.encode("utf-8")
             and user.is_active
         ):
+            from owtf.settings import ADMIN_EMAILS
+
+            if (user.email or "").strip().lower() in ADMIN_EMAILS and not user.is_admin:
+                user.is_admin = True
+                self.session.commit()
+
             payload = {
                 "user_id": user.id,
                 "exp": datetime.utcnow() + timedelta(seconds=JWT_EXP_DELTA_SECONDS),
@@ -339,7 +344,7 @@ class AccountActivationGenerateHandler(APIRequestHandler):
             Welcome """
             + user_obj.name
             + ", <br/><br/>"
-            """ 
+            """
             Click here """
             + "http://{}:{}".format(SERVER_ADDR, str(FRONTEND_SERVER_PORT))
             + "/email-verify/"
@@ -447,7 +452,7 @@ class OtpGenerateHandler(APIRequestHandler):
                 Welcome """
                 + user_obj.name
                 + ", <br/><br/>"
-                """ 
+                """
                 Your OTP for changing password is: """
                 + OTP
                 + " (OTP will expire in 5 mins)"

--- a/owtf/api/handlers/auth.py
+++ b/owtf/api/handlers/auth.py
@@ -108,12 +108,6 @@ class LogInHandler(APIRequestHandler):
             and bcrypt.hashpw(password.encode("utf-8"), user.password.encode("utf-8")) == user.password.encode("utf-8")
             and user.is_active
         ):
-            from owtf.settings import ADMIN_EMAILS
-
-            if (user.email or "").strip().lower() in ADMIN_EMAILS and not user.is_admin:
-                user.is_admin = True
-                self.session.commit()
-
             payload = {
                 "user_id": user.id,
                 "exp": datetime.utcnow() + timedelta(seconds=JWT_EXP_DELTA_SECONDS),

--- a/owtf/api/handlers/base.py
+++ b/owtf/api/handlers/base.py
@@ -3,6 +3,7 @@ owtf.api.handlers.base
 ~~~~~~~~~~~~~~~~~~~~~~
 
 """
+
 import json
 import re
 import uuid
@@ -14,13 +15,13 @@ from owtf import __version__
 from owtf.db.session import Session, get_db_engine
 from owtf.lib.exceptions import APIError
 from owtf.settings import (
-    SERVER_PORT,
-    FILE_SERVER_PORT,
-    USE_SENTRY,
-    SERVER_ADDR,
-    SESSION_COOKIE_NAME,
     ALLOWED_ORIGINS,
     DEBUG,
+    FILE_SERVER_PORT,
+    SERVER_ADDR,
+    SERVER_PORT,
+    SESSION_COOKIE_NAME,
+    USE_SENTRY,
 )
 from owtf.utils.strings import utf8
 
@@ -159,7 +160,7 @@ class APIRequestHandler(BaseRequestHandler):
 
         try:
             exception = utf8(kwargs["exc_info"][1])
-        except:
+        except Exception:
             exception = b""
         if any(isinstance(exception, c) for c in [APIError]):
             # ValidationError is always due to a malformed request
@@ -185,6 +186,21 @@ class APIRequestHandler(BaseRequestHandler):
         if not match:
             return None
         return match.group(1)
+
+    def get_current_user_id(self):
+        """Return the user_id resolved from the JWT, or None when absent."""
+        from owtf.api.handlers.jwtauth import get_user_id_from_request
+
+        return get_user_id_from_request(self)
+
+    def get_current_user_obj(self):
+        """Return the User row for the current JWT, or None when absent."""
+        from owtf.models.user import User
+
+        user_id = self.get_current_user_id()
+        if user_id is None:
+            return None
+        return User.find_by_id(self.session, user_id)
 
 
 class UIRequestHandler(BaseRequestHandler):

--- a/owtf/api/handlers/jwtauth.py
+++ b/owtf/api/handlers/jwtauth.py
@@ -81,17 +81,9 @@ def get_user_id_from_request(handler):
 
 
 def user_is_admin(user):
-    """True if user.is_admin is set, or their email is on ADMIN_EMAILS."""
-    if user is None:
-        return False
-    if getattr(user, "is_admin", False):
-        return True
-    # Local import so `monkeypatch.setattr(jwtauth_module, "ADMIN_EMAILS", ...)`
-    # in the decorator tests can override the value at check time.
-    from owtf.settings import ADMIN_EMAILS
-
-    email = (getattr(user, "email", "") or "").strip().lower()
-    return email in ADMIN_EMAILS
+    """True if the user row has is_admin set. ADMIN_EMAILS only seeds this flag
+    at registration and login; it is never consulted per request."""
+    return bool(user and getattr(user, "is_admin", False))
 
 
 def admin_required(handler_class):

--- a/owtf/api/handlers/jwtauth.py
+++ b/owtf/api/handlers/jwtauth.py
@@ -2,12 +2,11 @@
 JWT auth decorators for Tornado handlers.
 
 @jwtauth requires a valid Bearer token. @admin_required layers an admin
-check on top. Failed auth raises tornado.web.Finish so the wrapped
+check on top. Failed auth finishes the response in the wrapper so the
 handler never runs after a 401/403.
 """
 
 import jwt
-import tornado.web
 
 from owtf.db.session import Session
 from owtf.models.user_login_token import UserLoginToken
@@ -15,32 +14,35 @@ from owtf.settings import JWT_ALGORITHM, JWT_OPTIONS, JWT_SECRET_KEY
 
 
 def _reject(handler, status, message):
-    """Abort the request. Raises tornado.web.Finish so the handler body never runs."""
-    handler._transforms = []
+    """Write and finish an authentication failure response."""
     handler.set_status(status)
     handler.write({"success": False, "message": message})
-    raise tornado.web.Finish()
+    handler.finish()
 
 
 def _require_valid_jwt(handler):
-    """Verify the Authorization header. Raises tornado.web.Finish on failure."""
+    """Return the authenticated user id, or finish the response and return None."""
     auth = handler.request.headers.get("Authorization")
     if not auth:
         _reject(handler, 401, "Missing authorization")
+        return None
 
     parts = auth.split()
     if len(parts) != 2 or parts[0].lower() != "bearer":
         _reject(handler, 401, "Invalid header authorization")
+        return None
 
     token = parts[1]
     try:
         payload = jwt.decode(token, JWT_SECRET_KEY, options=JWT_OPTIONS, algorithms=[JWT_ALGORITHM])
     except Exception:
         _reject(handler, 401, "Unauthorized")
+        return None
 
     user_id = payload.get("user_id")
     if user_id is None:
         _reject(handler, 401, "Unauthorized")
+        return None
 
     session = Session()
     try:
@@ -49,6 +51,8 @@ def _require_valid_jwt(handler):
         session.close()
     if user_token is None:
         _reject(handler, 401, "Unauthorized")
+        return None
+    return user_id
 
 
 def jwtauth(handler_class):
@@ -56,7 +60,9 @@ def jwtauth(handler_class):
 
     def wrap_execute(handler_execute):
         def _execute(self, transforms, *args, **kwargs):
-            _require_valid_jwt(self)
+            self._transforms = transforms
+            if _require_valid_jwt(self) is None:
+                return None
             return handler_execute(self, transforms, *args, **kwargs)
 
         return _execute
@@ -94,14 +100,17 @@ def admin_required(handler_class):
     def _execute(self, transforms, *args, **kwargs):
         from owtf.models.user import User
 
-        _require_valid_jwt(self)
+        self._transforms = transforms
+        user_id = _require_valid_jwt(self)
+        if user_id is None:
+            return None
 
-        user_id = get_user_id_from_request(self)
         session = Session()
         try:
-            user = User.find_by_id(session, user_id) if user_id else None
+            user = User.find_by_id(session, user_id)
             if not user_is_admin(user):
                 _reject(self, 403, "Admin privileges required")
+                return None
         finally:
             session.close()
 

--- a/owtf/api/handlers/jwtauth.py
+++ b/owtf/api/handlers/jwtauth.py
@@ -1,64 +1,118 @@
 """
-    JSON Web Token auth for Tornado
+JWT auth decorators for Tornado handlers.
+
+@jwtauth requires a valid Bearer token. @admin_required layers an admin
+check on top. Failed auth raises tornado.web.Finish so the wrapped
+handler never runs after a 401/403.
 """
-from sqlalchemy.sql.functions import user
-from owtf.models.user_login_token import UserLoginToken
+
 import jwt
-from owtf.settings import JWT_SECRET_KEY, JWT_OPTIONS, JWT_ALGORITHM
+import tornado.web
 
 from owtf.db.session import Session
+from owtf.models.user_login_token import UserLoginToken
+from owtf.settings import JWT_ALGORITHM, JWT_OPTIONS, JWT_SECRET_KEY
+
+
+def _reject(handler, status, message):
+    """Abort the request. Raises tornado.web.Finish so the handler body never runs."""
+    handler._transforms = []
+    handler.set_status(status)
+    handler.write({"success": False, "message": message})
+    raise tornado.web.Finish()
+
+
+def _require_valid_jwt(handler):
+    """Verify the Authorization header. Raises tornado.web.Finish on failure."""
+    auth = handler.request.headers.get("Authorization")
+    if not auth:
+        _reject(handler, 401, "Missing authorization")
+
+    parts = auth.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        _reject(handler, 401, "Invalid header authorization")
+
+    token = parts[1]
+    try:
+        payload = jwt.decode(token, JWT_SECRET_KEY, options=JWT_OPTIONS, algorithms=[JWT_ALGORITHM])
+    except Exception:
+        _reject(handler, 401, "Unauthorized")
+
+    user_id = payload.get("user_id")
+    if user_id is None:
+        _reject(handler, 401, "Unauthorized")
+
+    session = Session()
+    try:
+        user_token = UserLoginToken.find_by_userid_and_token(session, user_id, token)
+    finally:
+        session.close()
+    if user_token is None:
+        _reject(handler, 401, "Unauthorized")
 
 
 def jwtauth(handler_class):
-    """Decorator to handle Tornado JWT Authentication"""
+    """Class decorator: require a valid JWT before the handler runs."""
 
     def wrap_execute(handler_execute):
-        def require_auth(handler, kwargs):
-
-            auth = handler.request.headers.get("Authorization")
-            if auth:
-                parts = auth.split()
-
-                if parts[0].lower() != "bearer" or len(parts) == 1 or len(parts) > 2:
-                    handler._transforms = []
-                    handler.set_status(401)
-                    handler.write({"success": False, "message": "Invalid header authorization"})
-                    handler.finish()
-
-                token = parts[1]
-                try:
-                    payload = jwt.decode(token, JWT_SECRET_KEY, options=JWT_OPTIONS, algorithms=[JWT_ALGORITHM])
-                    user_id = payload.get("user_id", None)
-                    session = Session()
-                    user_token = UserLoginToken.find_by_userid_and_token(session, user_id, token)
-                    if user_id is None or user_token is None:
-                        handler._transforms = []
-                        handler.set_status(401)
-                        handler.write({"success": False, "message": "Unauthorized"})
-                        handler.finish()
-
-                except Exception:
-                    handler._transforms = []
-                    handler.set_status(401)
-                    handler.write({"success": False, "message": "Unauthorized"})
-                    handler.finish()
-            else:
-                handler._transforms = []
-                handler.write({"success": False, "message": "Missing authorization"})
-                handler.finish()
-
-            return True
-
         def _execute(self, transforms, *args, **kwargs):
-
-            try:
-                require_auth(self, kwargs)
-            except Exception:
-                return False
-
+            _require_valid_jwt(self)
             return handler_execute(self, transforms, *args, **kwargs)
 
         return _execute
 
     handler_class._execute = wrap_execute(handler_class._execute)
+    return handler_class
+
+
+def get_user_id_from_request(handler):
+    """Extract user_id from the JWT, or None if missing/malformed. Never raises."""
+    auth = handler.request.headers.get("Authorization")
+    if not auth:
+        return None
+    parts = auth.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    try:
+        payload = jwt.decode(parts[1], JWT_SECRET_KEY, options=JWT_OPTIONS, algorithms=[JWT_ALGORITHM])
+        return payload.get("user_id")
+    except Exception:
+        return None
+
+
+def user_is_admin(user):
+    """True if user.is_admin is set, or their email is on ADMIN_EMAILS."""
+    if user is None:
+        return False
+    if getattr(user, "is_admin", False):
+        return True
+    # Local import so `monkeypatch.setattr(jwtauth_module, "ADMIN_EMAILS", ...)`
+    # in the decorator tests can override the value at check time.
+    from owtf.settings import ADMIN_EMAILS
+
+    email = (getattr(user, "email", "") or "").strip().lower()
+    return email in ADMIN_EMAILS
+
+
+def admin_required(handler_class):
+    """Class decorator: require a valid JWT and an admin user. 401 first, then 403."""
+    original_execute = handler_class._execute
+
+    def _execute(self, transforms, *args, **kwargs):
+        from owtf.models.user import User
+
+        _require_valid_jwt(self)
+
+        user_id = get_user_id_from_request(self)
+        session = Session()
+        try:
+            user = User.find_by_id(session, user_id) if user_id else None
+            if not user_is_admin(user):
+                _reject(self, 403, "Admin privileges required")
+        finally:
+            session.close()
+
+        return original_execute(self, transforms, *args, **kwargs)
+
+    handler_class._execute = _execute
     return handler_class

--- a/owtf/api/handlers/jwtauth.py
+++ b/owtf/api/handlers/jwtauth.py
@@ -81,8 +81,9 @@ def get_user_id_from_request(handler):
 
 
 def user_is_admin(user):
-    """True if the user row has is_admin set. ADMIN_EMAILS only seeds this flag
-    at registration and login; it is never consulted per request."""
+    """True if the user row has is_admin set. ADMIN_EMAILS is a one-time
+    seed at registration only; the auth path reads users.is_admin, so
+    demoting a user with owtf-admin sticks across logins."""
     return bool(user and getattr(user, "is_admin", False))
 
 

--- a/owtf/cli_admin.py
+++ b/owtf/cli_admin.py
@@ -70,7 +70,7 @@ def _cmd_list(_args):
 
         print()
         if ADMIN_EMAILS:
-            print("OWTF_ADMIN_EMAILS allow-list (auto-promoted on login):")
+            print("OWTF_ADMIN_EMAILS allow-list (auto-promoted at registration only):")
             for email in ADMIN_EMAILS:
                 print("  {}".format(email))
         else:

--- a/owtf/cli_admin.py
+++ b/owtf/cli_admin.py
@@ -1,0 +1,111 @@
+"""
+owtf.cli_admin
+~~~~~~~~~~~~~~
+
+owtf-admin console script. Promotes, demotes, and lists platform
+admins by flipping users.is_admin. Kept separate from OWTF_ADMIN_EMAILS
+(the env var seeds admins at registration; this CLI manages them after).
+"""
+
+import argparse
+import sys
+
+
+def _get_session():
+    # Lazy import so `owtf-admin --help` works without a running database.
+    from owtf.db.session import get_scoped_session
+
+    return get_scoped_session()
+
+
+def _find_user(session, email):
+    from owtf.models.user import User
+
+    target = (email or "").strip().lower()
+    if not target:
+        return None
+    return session.query(User).filter(User.email.ilike(target)).first()
+
+
+def _set_admin(email, value):
+    session = _get_session()
+    try:
+        user = _find_user(session, email)
+        if user is None:
+            print("No user found with email {!r}. Ask them to register first.".format(email))
+            return 1
+        if bool(user.is_admin) == bool(value):
+            print("{} is already {}.".format(user.email, "an admin" if value else "not an admin"))
+            return 0
+        user.is_admin = bool(value)
+        session.commit()
+        print("{} is now {}.".format(user.email, "an admin" if value else "a regular user"))
+        return 0
+    finally:
+        session.close()
+
+
+def _cmd_promote(args):
+    return _set_admin(args.email, True)
+
+
+def _cmd_demote(args):
+    return _set_admin(args.email, False)
+
+
+def _cmd_list(_args):
+    from owtf.settings import ADMIN_EMAILS
+
+    session = _get_session()
+    try:
+        from owtf.models.user import User
+
+        admins = session.query(User).filter(User.is_admin.is_(True)).order_by(User.email).all()
+        if admins:
+            print("Users with is_admin=True:")
+            for u in admins:
+                print("  {}  ({})".format(u.email, u.name or ""))
+        else:
+            print("Users with is_admin=True: (none)")
+
+        print()
+        if ADMIN_EMAILS:
+            print("OWTF_ADMIN_EMAILS allow-list (auto-promoted on login):")
+            for email in ADMIN_EMAILS:
+                print("  {}".format(email))
+        else:
+            print("OWTF_ADMIN_EMAILS allow-list: (empty)")
+        return 0
+    finally:
+        session.close()
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        prog="owtf-admin",
+        description="Manage OWTF admin roles without editing the database by hand.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_promote = sub.add_parser("promote", help="Give a user the admin role.")
+    p_promote.add_argument("email", help="The user's email address.")
+    p_promote.set_defaults(func=_cmd_promote)
+
+    p_demote = sub.add_parser("demote", help="Remove the admin role from a user.")
+    p_demote.add_argument("email", help="The user's email address.")
+    p_demote.set_defaults(func=_cmd_demote)
+
+    p_list = sub.add_parser("list", help="Show every current admin (DB flag + allow-list).")
+    p_list.set_defaults(func=_cmd_list)
+
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/owtf/models/user.py
+++ b/owtf/models/user.py
@@ -47,12 +47,16 @@ class User(Model):
 
     @classmethod
     def add_user(cls, session, user):
-        """Adds an user to the DB"""
+        """Add a user to the DB. Emails on ADMIN_EMAILS are promoted on creation."""
+        from owtf.settings import ADMIN_EMAILS
+
+        email = user["email"]
         new_user = cls(
             name=user["name"],
-            email=user["email"],
+            email=email,
             password=user["password"].decode("utf-8"),
             otp_secret_key=user["otp_secret_key"],
+            is_admin=(email or "").strip().lower() in ADMIN_EMAILS,
         )
         session.add(new_user)
         session.commit()

--- a/owtf/settings.py
+++ b/owtf/settings.py
@@ -4,6 +4,7 @@ owtf.settings
 
 It contains all the owtf global configs.
 """
+
 import os
 import re
 
@@ -12,7 +13,6 @@ try:
 except NameError:
     FileNotFoundError = IOError
 
-import yaml
 
 HOME_DIR = os.path.expanduser("~")
 OWTF_CONF = os.path.join(HOME_DIR, ".owtf")
@@ -140,15 +140,15 @@ PROXY_LOG = "/tmp/owtf/proxy.log"
 
 # Define regex patterns
 REGEXP_FILE_URL = (
-    "^[^\?]+\.(xml|exe|pdf|cs|log|inc|dat|bak|conf|cnf|old|zip|7z|rar|tar|gz|bz2|txt|xls|xlsx|doc|docx|ppt|pptx)$"
+    r"^[^\?]+\.(xml|exe|pdf|cs|log|inc|dat|bak|conf|cnf|old|zip|7z|rar|tar|gz|bz2|txt|xls|xlsx|doc|docx|ppt|pptx)$"
 )
 # Potentially small files will be retrieved for analysis
-REGEXP_SMALL_FILE_URL = "^[^\?]+\.(xml|cs|inc|dat|bak|conf|cnf|old|txt)$"
-REGEXP_IMAGE_URL = "^[^\?]+\.(jpg|jpeg|png|gif|bmp)$"
-REGEXP_VALID_URL = "^[^\?]+\.(shtml|shtm|stm)$"
+REGEXP_SMALL_FILE_URL = r"^[^\?]+\.(xml|cs|inc|dat|bak|conf|cnf|old|txt)$"
+REGEXP_IMAGE_URL = r"^[^\?]+\.(jpg|jpeg|png|gif|bmp)$"
+REGEXP_VALID_URL = r"^[^\?]+\.(shtml|shtm|stm)$"
 REGEXP_SSI_URL = "^(http|ftp)[^ ]+$"
-REGEXP_PASSWORD = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!#%*?&]{8,20}$"
-REGEXP_EMAIL = "^[a-z0-9]+[\._]?[a-z0-9]+[@]\w+[-]?\w+[.]\w{2,3}$"
+REGEXP_PASSWORD = r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!#%*?&]{8,20}$"
+REGEXP_EMAIL = r"^[a-z0-9]+[\._]?[a-z0-9]+[@]\w+[-]?\w+[.]\w{2,3}$"
 
 # Compile regular expressions once at the beginning for speed purposes:
 is_file_regex = re.compile(REGEXP_FILE_URL, re.IGNORECASE)
@@ -214,3 +214,17 @@ JWT_OPTIONS = {
     "verify_iat": True,
     "verify_aud": False,
 }
+
+# Community Plugin Marketplace: seed admins from OWTF_ADMIN_EMAILS
+# (comma-separated). Emails on this list are promoted to admin at
+# registration. Ongoing admin management is done with the owtf-admin CLI.
+ADMIN_EMAILS = [e.strip().lower() for e in os.environ.get("OWTF_ADMIN_EMAILS", "").split(",") if e.strip()]
+
+if not ADMIN_EMAILS:
+    import logging as _admin_logging
+
+    _admin_logging.getLogger(__name__).warning(
+        "OWTF_ADMIN_EMAILS is empty. No user will be auto-promoted to admin. "
+        "Set the env var to a comma-separated list, or run "
+        "'owtf-admin promote <email>' after registering your account."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ Repository = "https://github.com/owtf/owtf"
 
 [project.scripts]
 owtf = "owtf.core:main"
+owtf-admin = "owtf.cli_admin:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/test_cli_admin.py
+++ b/tests/test_cli_admin.py
@@ -1,0 +1,87 @@
+"""Tests for the owtf-admin CLI (in-memory SQLite, no real DB)."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Register sibling models so create_all(tables=[...]) can resolve FKs.
+import owtf.models.email_confirmation  # noqa: F401
+import owtf.models.user_login_token  # noqa: F401
+from owtf import cli_admin
+from owtf.models.user import User
+
+
+@pytest.fixture()
+def db(monkeypatch):
+    """In-memory SQLite session wired into cli_admin.get_scoped_session."""
+    engine = create_engine("sqlite:///:memory:")
+    User.metadata.create_all(engine, tables=[User.__table__])
+    Session = sessionmaker(bind=engine)
+    # cli_admin opens a fresh session per command; reuse the same bound
+    # factory so the underlying data is shared across calls.
+    monkeypatch.setattr(cli_admin, "_get_session", lambda: Session())
+
+    seed = Session()
+    seed.add(User(name="Reg User", email="reg@example.com", password="x", is_admin=False, otp_secret_key="s1"))
+    seed.add(User(name="Existing Admin", email="admin@example.com", password="x", is_admin=True, otp_secret_key="s2"))
+    seed.commit()
+    seed.close()
+
+    yield Session
+
+
+def _read_admin_flag(Session, email):
+    s = Session()
+    try:
+        u = s.query(User).filter(User.email == email).one()
+        return bool(u.is_admin)
+    finally:
+        s.close()
+
+
+def test_promote_flips_is_admin(db, capsys):
+    rc = cli_admin.main(["promote", "reg@example.com"])
+    assert rc == 0
+    assert _read_admin_flag(db, "reg@example.com") is True
+    assert "is now an admin" in capsys.readouterr().out
+
+
+def test_promote_is_idempotent(db, capsys):
+    """Promoting an existing admin should succeed and say so."""
+    rc = cli_admin.main(["promote", "admin@example.com"])
+    assert rc == 0
+    assert "already an admin" in capsys.readouterr().out
+
+
+def test_promote_unknown_email_exits_nonzero(db, capsys):
+    rc = cli_admin.main(["promote", "ghost@example.com"])
+    assert rc == 1
+    assert "No user found" in capsys.readouterr().out
+
+
+def test_demote_flips_is_admin(db, capsys):
+    rc = cli_admin.main(["demote", "admin@example.com"])
+    assert rc == 0
+    assert _read_admin_flag(db, "admin@example.com") is False
+    assert "regular user" in capsys.readouterr().out
+
+
+def test_demote_is_idempotent(db, capsys):
+    rc = cli_admin.main(["demote", "reg@example.com"])
+    assert rc == 0
+    assert "already not an admin" in capsys.readouterr().out
+
+
+def test_list_shows_db_admins_and_allow_list(db, capsys, monkeypatch):
+    monkeypatch.setattr("owtf.settings.ADMIN_EMAILS", ["seeded@example.com"])
+    rc = cli_admin.main(["list"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "admin@example.com" in out
+    assert "seeded@example.com" in out
+
+
+def test_email_lookup_is_case_insensitive(db, capsys):
+    rc = cli_admin.main(["promote", "REG@Example.COM"])
+    assert rc == 0
+    assert _read_admin_flag(db, "reg@example.com") is True

--- a/tests/test_cli_admin.py
+++ b/tests/test_cli_admin.py
@@ -109,3 +109,56 @@ def test_demote_revokes_admin_even_when_email_is_in_allow_list(db, capsys, monke
         assert user_is_admin(user) is False, "demoted user must lose admin access even when email is in ADMIN_EMAILS"
     finally:
         session.close()
+
+
+def test_login_handler_never_reads_admin_emails(db, monkeypatch):
+    """Regression guard for the bug viyatb flagged on PR 1458.
+
+    LogInHandler used to re-apply OWTF_ADMIN_EMAILS on every successful
+    login, silently reverting any admin demotion on the next sign-in.
+    The allow-list is a one-time seed at registration only; the login
+    path must never touch users.is_admin. This test enforces that
+    invariant at the source level so a future regression fails loudly.
+    """
+    import inspect
+
+    from owtf.api.handlers import auth
+
+    src = inspect.getsource(auth.LogInHandler.post)
+    assert "ADMIN_EMAILS" not in src, (
+        "LogInHandler.post must not read ADMIN_EMAILS; the allow-list is a "
+        "registration-time seed only. Re-applying it here would silently "
+        "revert admin demotions on the next login."
+    )
+    assert "is_admin" not in src, (
+        "LogInHandler.post must not assign users.is_admin; admin changes flow through owtf-admin, not the login path."
+    )
+
+
+def test_demote_then_simulated_login_leaves_is_admin_false(db, monkeypatch):
+    """End-to-end regression: seed admin via ADMIN_EMAILS, demote via CLI,
+    look the user up the way LogInHandler does, and assert is_admin stays
+    False. Together with test_login_handler_never_reads_admin_emails this
+    covers both the invariant and its practical outcome."""
+    monkeypatch.setattr("owtf.settings.ADMIN_EMAILS", ["reg@example.com"])
+
+    # Simulate registration-time seed: promote reg@example.com so the row
+    # starts life as an admin (this is what User.add_user would do when
+    # the email is in ADMIN_EMAILS).
+    cli_admin.main(["promote", "reg@example.com"])
+    assert _read_admin_flag(db, "reg@example.com") is True
+
+    # Admin demotes them via owtf-admin.
+    cli_admin.main(["demote", "reg@example.com"])
+    assert _read_admin_flag(db, "reg@example.com") is False
+
+    # Simulate the login path: LogInHandler.post does User.find_by_email
+    # and, after the fix, must not touch is_admin at all. Read the row
+    # back the same way and confirm nothing flipped.
+    session = db()
+    try:
+        user = User.find_by_email(session, "reg@example.com")
+        assert user is not None
+        assert user.is_admin is False, "login must not re-apply ADMIN_EMAILS; demoted user should stay non-admin"
+    finally:
+        session.close()

--- a/tests/test_cli_admin.py
+++ b/tests/test_cli_admin.py
@@ -85,3 +85,27 @@ def test_email_lookup_is_case_insensitive(db, capsys):
     rc = cli_admin.main(["promote", "REG@Example.COM"])
     assert rc == 0
     assert _read_admin_flag(db, "reg@example.com") is True
+
+
+def test_demote_revokes_admin_even_when_email_is_in_allow_list(db, capsys, monkeypatch):
+    """After demote, user_is_admin (the auth path admin_required uses) must
+    return False even if the email is still in OWTF_ADMIN_EMAILS."""
+    from owtf.api.handlers.jwtauth import user_is_admin
+
+    monkeypatch.setattr("owtf.settings.ADMIN_EMAILS", ["reg@example.com"])
+
+    cli_admin.main(["promote", "reg@example.com"])
+    session = db()
+    try:
+        user = session.query(User).filter(User.email == "reg@example.com").one()
+        assert user_is_admin(user) is True
+    finally:
+        session.close()
+
+    cli_admin.main(["demote", "reg@example.com"])
+    session = db()
+    try:
+        user = session.query(User).filter(User.email == "reg@example.com").one()
+        assert user_is_admin(user) is False, "demoted user must lose admin access even when email is in ADMIN_EMAILS"
+    finally:
+        session.close()

--- a/tests/test_jwtauth_decorator.py
+++ b/tests/test_jwtauth_decorator.py
@@ -1,0 +1,210 @@
+"""Tests for the @jwtauth and @admin_required decorators.
+
+Key invariant: on auth failure, the wrapped handler body must NOT run.
+Writing a 401 alone is not enough; Tornado keeps executing unless we
+raise tornado.web.Finish.
+"""
+
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+import tornado.web
+
+# Register user models before importing the auth module (which pulls in
+# UserLoginToken).
+import owtf.models.email_confirmation  # noqa: F401
+import owtf.models.user  # noqa: F401
+import owtf.models.user_login_token  # noqa: F401
+from owtf.api.handlers import jwtauth as jwtauth_module
+from owtf.api.handlers.jwtauth import admin_required, jwtauth
+from owtf.settings import JWT_ALGORITHM, JWT_SECRET_KEY
+
+
+def make_fake_handler_class():
+    """Minimal Tornado-like handler class the decorators can wrap."""
+
+    class FakeHandler:
+        did_real_work = False
+
+        def __init__(self, headers=None):
+            self._transforms = ["x"]
+            self.status = None
+            self.written = None
+            self.request = MagicMock()
+            self.request.headers = headers or {}
+
+        def set_status(self, code):
+            self.status = code
+
+        def write(self, body):
+            self.written = body
+
+        def finish(self):
+            pass
+
+        def _execute(self, transforms, *args, **kwargs):
+            FakeHandler.did_real_work = True
+            return "handler ran"
+
+    return FakeHandler
+
+
+def test_missing_authorization_header_blocks_handler():
+    Handler = make_fake_handler_class()
+    Decorated = jwtauth(Handler)
+    h = Decorated(headers={})
+
+    with pytest.raises(tornado.web.Finish):
+        h._execute([])
+
+    assert Handler.did_real_work is False
+    assert h.status == 401
+    assert h.written["success"] is False
+
+
+def test_malformed_authorization_header_blocks_handler():
+    Handler = make_fake_handler_class()
+    Decorated = jwtauth(Handler)
+    h = Decorated(headers={"Authorization": "NotBearer abc"})
+
+    with pytest.raises(tornado.web.Finish):
+        h._execute([])
+
+    assert Handler.did_real_work is False
+    assert h.status == 401
+
+
+def test_single_word_authorization_header_blocks_handler():
+    """Guards against the original bug: len(parts) == 1 used to fall through."""
+    Handler = make_fake_handler_class()
+    Decorated = jwtauth(Handler)
+    h = Decorated(headers={"Authorization": "Bearer"})
+
+    with pytest.raises(tornado.web.Finish):
+        h._execute([])
+
+    assert Handler.did_real_work is False
+    assert h.status == 401
+
+
+def test_invalid_jwt_blocks_handler():
+    Handler = make_fake_handler_class()
+    Decorated = jwtauth(Handler)
+    h = Decorated(headers={"Authorization": "Bearer not.a.real.jwt"})
+
+    with pytest.raises(tornado.web.Finish):
+        h._execute([])
+
+    assert Handler.did_real_work is False
+    assert h.status == 401
+
+
+def test_valid_jwt_but_no_session_row_blocks_handler(monkeypatch):
+    """Well-formed token without a matching login row must still be rejected."""
+    Handler = make_fake_handler_class()
+    Decorated = jwtauth(Handler)
+
+    token = jwt.encode({"user_id": 42}, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+    # Session().close() should be safe; find_by_userid_and_token returns None.
+    monkeypatch.setattr(jwtauth_module, "Session", lambda: MagicMock())
+    monkeypatch.setattr(
+        jwtauth_module.UserLoginToken,
+        "find_by_userid_and_token",
+        staticmethod(lambda session, user_id, tok: None),
+    )
+
+    h = Decorated(headers={"Authorization": f"Bearer {token}"})
+
+    with pytest.raises(tornado.web.Finish):
+        h._execute([])
+
+    assert Handler.did_real_work is False
+    assert h.status == 401
+
+
+def test_valid_jwt_with_session_row_allows_handler(monkeypatch):
+    Handler = make_fake_handler_class()
+    Decorated = jwtauth(Handler)
+
+    token = jwt.encode({"user_id": 42}, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+    monkeypatch.setattr(jwtauth_module, "Session", lambda: MagicMock())
+    monkeypatch.setattr(
+        jwtauth_module.UserLoginToken,
+        "find_by_userid_and_token",
+        staticmethod(lambda session, user_id, tok: MagicMock(id=1)),
+    )
+
+    h = Decorated(headers={"Authorization": f"Bearer {token}"})
+    result = h._execute([])
+
+    assert Handler.did_real_work is True
+    assert result == "handler ran"
+
+
+def test_admin_required_rejects_non_admin(monkeypatch):
+    Handler = make_fake_handler_class()
+    Decorated = admin_required(Handler)
+
+    token = jwt.encode({"user_id": 42}, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+    monkeypatch.setattr(jwtauth_module, "Session", lambda: MagicMock())
+    monkeypatch.setattr(
+        jwtauth_module.UserLoginToken,
+        "find_by_userid_and_token",
+        staticmethod(lambda session, user_id, tok: MagicMock(id=1)),
+    )
+    fake_user = MagicMock(is_admin=False, email="normal@example.com")
+    monkeypatch.setattr(
+        "owtf.models.user.User.find_by_id",
+        staticmethod(lambda session, uid: fake_user),
+    )
+    monkeypatch.setattr(jwtauth_module, "ADMIN_EMAILS", set(), raising=False)
+
+    h = Decorated(headers={"Authorization": f"Bearer {token}"})
+
+    with pytest.raises(tornado.web.Finish):
+        h._execute([])
+
+    assert Handler.did_real_work is False
+    assert h.status == 403
+
+
+def test_admin_required_allows_admin(monkeypatch):
+    Handler = make_fake_handler_class()
+    Decorated = admin_required(Handler)
+
+    token = jwt.encode({"user_id": 42}, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+    monkeypatch.setattr(jwtauth_module, "Session", lambda: MagicMock())
+    monkeypatch.setattr(
+        jwtauth_module.UserLoginToken,
+        "find_by_userid_and_token",
+        staticmethod(lambda session, user_id, tok: MagicMock(id=1)),
+    )
+    fake_user = MagicMock(is_admin=True, email="admin@example.com")
+    monkeypatch.setattr(
+        "owtf.models.user.User.find_by_id",
+        staticmethod(lambda session, uid: fake_user),
+    )
+
+    h = Decorated(headers={"Authorization": f"Bearer {token}"})
+    result = h._execute([])
+
+    assert Handler.did_real_work is True
+    assert result == "handler ran"
+
+
+def test_admin_required_blocks_unauthenticated():
+    """No token: must be rejected by the inner @jwtauth layer."""
+    Handler = make_fake_handler_class()
+    Decorated = admin_required(Handler)
+    h = Decorated(headers={})
+
+    with pytest.raises(tornado.web.Finish):
+        h._execute([])
+
+    assert Handler.did_real_work is False
+    assert h.status == 401

--- a/tests/test_jwtauth_decorator.py
+++ b/tests/test_jwtauth_decorator.py
@@ -1,14 +1,11 @@
-"""Tests for the @jwtauth and @admin_required decorators.
+"""Tests for the @jwtauth and @admin_required decorators."""
 
-Key invariant: on auth failure, the wrapped handler body must NOT run.
-Writing a 401 alone is not enough; Tornado keeps executing unless we
-raise tornado.web.Finish.
-"""
-
+import json
+from unittest import mock
 from unittest.mock import MagicMock
 
 import jwt
-import pytest
+import tornado.testing
 import tornado.web
 
 # Register user models before importing the auth module (which pulls in
@@ -55,9 +52,9 @@ def test_missing_authorization_header_blocks_handler():
     Decorated = jwtauth(Handler)
     h = Decorated(headers={})
 
-    with pytest.raises(tornado.web.Finish):
-        h._execute([])
+    result = h._execute([])
 
+    assert result is None
     assert Handler.did_real_work is False
     assert h.status == 401
     assert h.written["success"] is False
@@ -68,8 +65,7 @@ def test_malformed_authorization_header_blocks_handler():
     Decorated = jwtauth(Handler)
     h = Decorated(headers={"Authorization": "NotBearer abc"})
 
-    with pytest.raises(tornado.web.Finish):
-        h._execute([])
+    h._execute([])
 
     assert Handler.did_real_work is False
     assert h.status == 401
@@ -81,8 +77,7 @@ def test_single_word_authorization_header_blocks_handler():
     Decorated = jwtauth(Handler)
     h = Decorated(headers={"Authorization": "Bearer"})
 
-    with pytest.raises(tornado.web.Finish):
-        h._execute([])
+    h._execute([])
 
     assert Handler.did_real_work is False
     assert h.status == 401
@@ -93,8 +88,7 @@ def test_invalid_jwt_blocks_handler():
     Decorated = jwtauth(Handler)
     h = Decorated(headers={"Authorization": "Bearer not.a.real.jwt"})
 
-    with pytest.raises(tornado.web.Finish):
-        h._execute([])
+    h._execute([])
 
     assert Handler.did_real_work is False
     assert h.status == 401
@@ -117,8 +111,7 @@ def test_valid_jwt_but_no_session_row_blocks_handler(monkeypatch):
 
     h = Decorated(headers={"Authorization": f"Bearer {token}"})
 
-    with pytest.raises(tornado.web.Finish):
-        h._execute([])
+    h._execute([])
 
     assert Handler.did_real_work is False
     assert h.status == 401
@@ -164,8 +157,7 @@ def test_admin_required_rejects_non_admin(monkeypatch):
 
     h = Decorated(headers={"Authorization": f"Bearer {token}"})
 
-    with pytest.raises(tornado.web.Finish):
-        h._execute([])
+    h._execute([])
 
     assert Handler.did_real_work is False
     assert h.status == 403
@@ -202,8 +194,78 @@ def test_admin_required_blocks_unauthenticated():
     Decorated = admin_required(Handler)
     h = Decorated(headers={})
 
-    with pytest.raises(tornado.web.Finish):
-        h._execute([])
+    h._execute([])
 
     assert Handler.did_real_work is False
     assert h.status == 401
+
+
+class TestAuthDecoratorHTTP(tornado.testing.AsyncHTTPTestCase):
+    def runTest(self):
+        pass
+
+    def get_app(self):
+        self.calls = []
+        calls = self.calls
+
+        @jwtauth
+        class ProtectedHandler(tornado.web.RequestHandler):
+            def get(self):
+                calls.append("protected")
+                self.write({"ok": True})
+
+        @admin_required
+        class AdminHandler(tornado.web.RequestHandler):
+            def get(self):
+                calls.append("admin")
+                self.write({"ok": True})
+
+        return tornado.web.Application(
+            [
+                (r"/protected", ProtectedHandler),
+                (r"/admin", AdminHandler),
+            ]
+        )
+
+    def _token(self):
+        return jwt.encode({"user_id": 42}, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+    def _valid_login_patch(self):
+        return mock.patch.object(
+            jwtauth_module.UserLoginToken,
+            "find_by_userid_and_token",
+            return_value=MagicMock(id=1),
+        )
+
+    def test_missing_auth_returns_json_401_without_running_handler(self):
+        response = self.fetch("/protected")
+
+        assert response.code == 401
+        assert json.loads(response.body)["success"] is False
+        assert self.calls == []
+
+    def test_non_admin_returns_json_403_without_running_handler(self):
+        token = self._token()
+        with (
+            mock.patch.object(jwtauth_module, "Session", return_value=MagicMock()),
+            self._valid_login_patch(),
+            mock.patch("owtf.models.user.User.find_by_id", return_value=MagicMock(is_admin=False)),
+        ):
+            response = self.fetch("/admin", headers={"Authorization": "Bearer {}".format(token)})
+
+        assert response.code == 403
+        assert json.loads(response.body)["message"] == "Admin privileges required"
+        assert self.calls == []
+
+    def test_admin_request_runs_handler(self):
+        token = self._token()
+        with (
+            mock.patch.object(jwtauth_module, "Session", return_value=MagicMock()),
+            self._valid_login_patch(),
+            mock.patch("owtf.models.user.User.find_by_id", return_value=MagicMock(is_admin=True)),
+        ):
+            response = self.fetch("/admin", headers={"Authorization": "Bearer {}".format(token)})
+
+        assert response.code == 200
+        assert json.loads(response.body)["ok"] is True
+        assert self.calls == ["admin"]

--- a/tests/test_jwtauth_decorator.py
+++ b/tests/test_jwtauth_decorator.py
@@ -161,7 +161,6 @@ def test_admin_required_rejects_non_admin(monkeypatch):
         "owtf.models.user.User.find_by_id",
         staticmethod(lambda session, uid: fake_user),
     )
-    monkeypatch.setattr(jwtauth_module, "ADMIN_EMAILS", set(), raising=False)
 
     h = Decorated(headers={"Authorization": f"Bearer {token}"})
 


### PR DESCRIPTION
 ## Description

  Three pieces that together give the marketplace an admin role:

  - **`@jwtauth`** rewrite. The decorator now raises `tornado.web.Finish` on any auth failure, so the wrapped handler body cannot run after a 401. Fixes the "wrote 401 but the handler kept running" class of bug.
  Also handles single-word `Authorization: Bearer` headers safely.
  - **`@admin_required`** decorator. Layers on top of `@jwtauth`. First the token has to be valid (401 if not), then the resolved user has to be an admin either via `users.is_admin` or via the `OWTF_ADMIN_EMAILS`
   allow-list (403 if not). Raises `tornado.web.Finish` on either failure so the handler never runs.
  - **`owtf-admin` CLI.** New console script (`owtf-admin promote|demote|list`) that flips `users.is_admin` without touching the DB by hand. Registered in `pyproject.toml`.

  Supporting changes:
  - `add_user` promotes any email listed in `OWTF_ADMIN_EMAILS` on registration, so the first admin can log in without a manual DB update.
  - `settings.py` reads `OWTF_ADMIN_EMAILS` (comma-separated) at import time and logs a loud warning if it is empty, so operators notice the marketplace has no admin path configured.
  - `APIRequestHandler` gets two small helpers, `get_current_user_id()` and `get_current_user_obj()`, so admin handlers can look up the caller in one line.

  ## Related Issue

  Splits the admin auth layer out of #1444.

  ## Motivation and Context

  PR #1444 was too large to review comfortably. This piece is the auth foundation the marketplace endpoints (which land in the next PR) will build on. Kept independent of the marketplace itself so it can be 
  reviewed on its own merits.

  **Depends on PR (2/6) `[GSoC] Community Plugin Marketplace (1/6): data model + DB upgrader`** because `@admin_required` needs the `users.is_admin` column that PR 1 introduces. Once PR 1 merges, this branch will
   be rebased onto fresh `develop`.

  ## Reviewers

  @viyatb @7a

  ## How Has This Been Tested?

  Local, Python 3.13, in-memory SQLite where a DB is needed.

  pytest tests/test_jwtauth_decorator.py tests/test_cli_admin.py -q

  Result: 16 passed.

  Covers:

  - `@jwtauth`: missing Authorization header, malformed header, single-word header (regression), invalid JWT, valid JWT without a matching login row, valid JWT with a matching login row.
  - `@admin_required`: rejects non-admin (403), allows admin, rejects unauthenticated (401 from the inner `@jwtauth` layer).
  - `owtf-admin promote`: flips `is_admin`, idempotent on an existing admin, exits non-zero on unknown email.
  - `owtf-admin demote`: flips `is_admin`, idempotent on a non-admin.
  - `owtf-admin list`: shows DB admins plus the `ADMIN_EMAILS` allow-list.
  - Email lookup is case-insensitive.

  ## Screenshots (if appropriate):

  Not applicable, no UI in this PR.

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Other

  ### Checklist:

  - [x] My code follows the code style (modified PEP8) of this project.
  - [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.