### PR TITLE
fix: correct inverted SIGKILL escalation in _signal_process()

### DIFF
--- a/owtf/utils/process.py
+++ b/owtf/utils/process.py
@@ -62,8 +62,8 @@ def _signal_process(pid, psignal=signal.SIGINT):
     for pid in children:
         pid.send_signal(psignal)
     gone, alive = psutil.wait_procs(children, timeout=TIMEOUT)
-    if not alive:
-        # send SIGKILL
+    if alive:
+        # send SIGKILL to the processes that survived the first signal
         for pid in alive:
             logging.debug("Process %d survived SIGTERM; trying SIGKILL", pid)
             pid.kill()

--- a/tests/owtf/test_process_signal_sigkill.py
+++ b/tests/owtf/test_process_signal_sigkill.py
@@ -1,0 +1,56 @@
+"""Regression test for owtf.utils.process._signal_process().
+
+The SIGTERM -> SIGKILL escalation guarded its SIGKILL loop with `if not alive:`,
+so the loop only ran when the survivor list was empty -- i.e. it never ran, and
+processes that ignored the first signal were never force-killed (leaked as
+orphans). This is the same inverted-condition bug fixed in WorkerManager._signal_children
+(that one is a separate function / separate PR); this covers the twin in
+utils.process, which WorkerManager.exit() relies on to reap worker process trees.
+"""
+
+import signal
+import unittest
+from unittest.mock import MagicMock, patch
+
+from owtf.utils import process
+
+
+class TestSignalProcessSigkillEscalation(unittest.TestCase):
+    def _run_with_survivors(self, survivors):
+        """Invoke _signal_process with a mocked psutil where wait_procs reports
+        `survivors` as still alive after the first signal. Returns the parent +
+        child mocks so the caller can assert on kill()."""
+        parent = MagicMock(name="parent")
+        child = MagicMock(name="child")
+        parent.children.return_value = [child]
+
+        with patch.object(process, "psutil") as psutil_mock:
+            psutil_mock.Process.return_value = parent
+            psutil_mock.wait_procs.return_value = ([], survivors)
+            process._signal_process(1234, signal.SIGTERM)
+        return parent, child
+
+    def test_survivor_receives_sigkill(self):
+        survivor = MagicMock(name="survivor")
+        self._run_with_survivors([survivor])
+        survivor.kill.assert_called_once()
+
+    def test_no_survivors_means_no_kill(self):
+        parent, child = self._run_with_survivors([])
+        child.kill.assert_not_called()
+        parent.kill.assert_not_called()
+
+    def test_first_signal_is_sent_to_parent_and_children(self):
+        parent = MagicMock(name="parent")
+        child = MagicMock(name="child")
+        parent.children.return_value = [child]
+        with patch.object(process, "psutil") as psutil_mock:
+            psutil_mock.Process.return_value = parent
+            psutil_mock.wait_procs.return_value = ([], [])
+            process._signal_process(1234, signal.SIGTERM)
+        child.send_signal.assert_called_once_with(signal.SIGTERM)
+        parent.send_signal.assert_called_once_with(signal.SIGTERM)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
Changes `if not alive:` to `if alive:` in owtf/utils/process._signal_process(), so processes that survive the first signal are actually SIGKILLed instead of the escalation loop being dead code.

## Related Issue
Fixes #1465

## Motivation and Context
_signal_process() is the reaper WorkerManager.exit() uses to terminate worker process trees. With the inverted guard, survivors were never force-killed and leaked as orphans -- a contributor to the web-mode "does not exit cleanly" behaviour that keeps the web/proxy functional tests excluded from CI. This is the twin of the WorkerManager._signal_children bug in #1412 (fixed separately), in a different function.

## Reviewers
@viyatb @7a

## How Has This Been Tested?
`pytest tests/owtf/test_process_signal_sigkill.py` -- 3 tests using a mocked psutil: a survivor receives kill(); no survivors means no kill(); the first signal reaches both parent and children. Confirmed the survivor-kill test fails on the current code (dead loop) before this fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style (modified PEP8) of this project.
- [ ] My change requires a change to the documentation.
- [x] Tests, linting, and type checks pass locally.
- [x] I have added myself to AUTHORS.md (done in the proxy-startup deprecated-APIs PR of this batch).